### PR TITLE
ui: translate all labels, buttons, and dialogs to Spanish

### DIFF
--- a/src/components/admin/NoticeGeneral.vue
+++ b/src/components/admin/NoticeGeneral.vue
@@ -18,7 +18,7 @@
             <div class="text-h2">Usuarios</div>
             <div class="text-subtitle1">
                 Para mantener los registros actualizados y garantizar una gestión eficiente
-                 de usuarios, te invitamos a administrar tu lista de usuarios o agregar nuevos.
+                de usuarios, te invitamos a administrar tu lista de usuarios o agregar nuevos.
             </div>
             <q-btn outline label="Ver más" class="q-mt-md" to="/admin/users"/>
           </div>
@@ -32,7 +32,7 @@
             <div class="text-h2">Roles</div>
             <div class="text-subtitle1">
                 Para garantizar una mayor seguridad, es esencial mantener actualizados y
-                 gestionar de manera adecuada los roles en el sistema.
+                gestionar de manera adecuada los roles en el sistema.
             </div>
             <q-btn outline label="Ver más" class="q-mt-md" to="/admin/roles"/>
           </div>

--- a/src/layouts/Dashboard.vue
+++ b/src/layouts/Dashboard.vue
@@ -51,7 +51,7 @@
             v-if="getMe.role[0] == 'administrador'"
           >
             <q-item-section class="text-weight-bold">
-              DASHBOARD
+              PANEL
             </q-item-section>
           </q-item>
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -52,7 +52,7 @@
         <q-tabs v-if="$q.screen.gt.xs">
           <q-route-tab to="/" label="Inicio" />
           <q-route-tab to="/artist-list" label="Artistas" />
-          <q-route-tab to="/about" label="More" />
+          <q-route-tab to="/about" label="Más" />
         </q-tabs>
         <!-- Fin de Links para navegar entre paginas -->
 
@@ -70,7 +70,7 @@
 
             <q-route-tab
               to="/dashboard/home"
-              label="Dashboard"
+              label="PANEL"
               v-if="isAuthenticated == true"
             />
           </q-tabs>
@@ -130,7 +130,7 @@
                 <q-icon name="dashboard" />
               </q-item-section>
               <q-item-section>
-                <q-item-label>Dashboard</q-item-label>
+                <q-item-label>Panel</q-item-label>
               </q-item-section>
             </q-item>
           </div>

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -57,8 +57,8 @@
           <div class="text-overline">Paso 1</div>
           <div class="text-h6 q-mt-sm q-mb-xs">Regístrate con nosostros</div>
           <div class="text-caption text-black">
-               Ingresa a nuestra app y regístrate de manera rápida y sencilla.
-               Solo necesitas unos minutos  para crear tu cuenta y estará todo listo.
+              Ingresa a nuestra app y regístrate de manera rápida y sencilla.
+              Solo necesitas unos minutos  para crear tu cuenta y estará todo listo.
           </div>
         </q-card-section>
 
@@ -73,7 +73,7 @@
       <q-separator />
       <q-card-actions>
         <q-btn flat color="primary" to="/register">
-          GO
+          Ir
         </q-btn>
       </q-card-actions>
     </q-card>
@@ -100,7 +100,7 @@
       <q-separator />
       <q-card-actions>
         <q-btn flat color="primary" to="/login">
-          GO
+          Ir
         </q-btn>
       </q-card-actions>
     </q-card>
@@ -125,7 +125,7 @@
       <q-separator />
       <q-card-actions>
         <q-btn flat color="primary" to="/login">
-          GO
+          Ir
         </q-btn>
       </q-card-actions>
     </q-card>
@@ -136,8 +136,8 @@
           <div class="text-overline">Paso 4</div>
           <div class="text-h6 q-mt-sm q-mb-xs">Contrata a tu Artista Favorito!</div>
           <div class="text-caption text-black">
-             Una vez que estés completamente satisfecho con todos los detalles,
-             confirma desde nuestra aplicación, de forma rápida y segura.
+            Una vez que estés completamente satisfecho con todos los detalles,
+            confirma desde nuestra aplicación, de forma rápida y segura.
           </div>
         </q-card-section>
 
@@ -152,7 +152,7 @@
       <q-separator />
       <q-card-actions>
         <q-btn flat color="primary" to="/login">
-          GO
+          Ir
         </q-btn>
       </q-card-actions>
     </q-card>
@@ -192,7 +192,7 @@
           7715678903
         </q-btn>
         <q-btn flat color="primary">
-          Reserve
+          Reservar
         </q-btn>
       </q-card-actions>
     </q-card>

--- a/src/pages/Admin/MusicalGenders/index.vue
+++ b/src/pages/Admin/MusicalGenders/index.vue
@@ -9,6 +9,7 @@
       :filter="filter"
       no-data-label="Sin registros"
       no-results-label="Ningún registro coincidente"
+      rows-per-page-label="Géneros por página"
     >
       <template v-slot:top>
         <b class="text-h5">
@@ -453,7 +454,8 @@ export default {
           .dialog({
             title: "Mensaje de confirmación",
             message: `¿Estas seguro de eliminar el registro de ${name}`,
-            cancel: true,
+            cancel: "Cancelar",
+            ok: "Confirmar",
             persistent: true,
           })
           .onOk(() => {

--- a/src/pages/Admin/Roles/create.vue
+++ b/src/pages/Admin/Roles/create.vue
@@ -52,9 +52,9 @@
       </div>
 
       <div>
-        <q-btn label="Submit" type="submit" color="primary" />
+        <q-btn label="Enviar" type="submit" color="primary" />
         <q-btn
-          label="Reset"
+          label="Reiniciar"
           type="reset"
           color="primary"
           flat

--- a/src/pages/Admin/Roles/index.vue
+++ b/src/pages/Admin/Roles/index.vue
@@ -9,6 +9,7 @@
       :filter="filter"
       no-data-label="Sin registros"
       no-results-label="Ningún registro coincidente"
+      rows-per-page-label="Roles por página"
     >
       <template v-slot:top>
         <b class="text-h5">
@@ -225,10 +226,10 @@
           </q-card-section>
 
           <q-card-actions align="right" class="text-primary">
-            <q-btn flat label="Cancel" v-close-popup @click="onReset" />
+            <q-btn flat label="Cancelar" v-close-popup @click="onReset" />
             <q-btn
               flat
-              label="Submit"
+              label="Enviar"
               type="submit"
               v-close-popup
               v-on:click="editRole"
@@ -330,7 +331,8 @@ export default {
           .dialog({
             title: "Mensaje de confirmación",
             message: `¿Estas seguro de eliminar el registro de ${name}`,
-            cancel: true,
+            cancel: "Cancelar",
+            ok: "Confirmar",
             persistent: true,
           })
           .onOk(() => {

--- a/src/pages/Admin/Users/index.vue
+++ b/src/pages/Admin/Users/index.vue
@@ -9,6 +9,7 @@
       :filter="filter"
       no-data-label="Sin registros"
       no-results-label="Ningún registro coincidente"
+      rows-per-page-label="Usuarios por página"
     >
       <template v-slot:top>
         <b class="text-h5">
@@ -142,8 +143,8 @@
               />
               <!-- Fin Select -->
               <q-card-actions align="right" class="text-primary">
-                <q-btn flat label="Cancel" v-close-popup color="red" />
-                <q-btn flat label="Submit" type="submit" color="primary" />
+                <q-btn flat label="Cancelar" v-close-popup color="red" />
+                <q-btn flat label="Enviar" type="submit" color="primary" />
               </q-card-actions>
             </q-form>
           </q-card-section>
@@ -201,8 +202,8 @@
               />
               <!-- Fin Select -->
               <q-card-actions align="right" class="text-primary">
-                <q-btn flat label="Cancel" v-close-popup color="red" />
-                <q-btn flat label="Submit" type="submit" color="primary" />
+                <q-btn flat label="Cancelar" v-close-popup color="red" />
+                <q-btn flat label="Enviar" type="submit" color="primary" />
               </q-card-actions>
             </q-form>
           </q-card-section>
@@ -342,7 +343,8 @@ export default {
         .dialog({
           title: "Mensaje de confirmación",
           message: `¿Estas seguro de eliminar el registro de ${props.row.name}`,
-          cancel: true,
+          cancel: "Cancelar",
+          ok: "Confirmar",
           persistent: true,
         })
         .onOk(() => {

--- a/src/pages/Client/FavouriteArtists/index.vue
+++ b/src/pages/Client/FavouriteArtists/index.vue
@@ -9,6 +9,7 @@
         row-key="name"
         no-data-label="Sin registros"
         no-results-label="Ningún registro coincidente"
+        rows-per-page-label="Favoritos por página"
       >
         <template v-slot:top-left>
           <p class="q-mt-sm q-mb-sm text-h4" v-if="skeleton == false">

--- a/src/pages/Client/MusicalGenders/search.vue
+++ b/src/pages/Client/MusicalGenders/search.vue
@@ -65,6 +65,7 @@
         hide-header
         no-data-label="Sin registros"
         no-results-label="Ningún registro coincidente"
+        rows-per-page-label="Géneros por página"
       >
         <template v-slot:top-left>
           <h5

--- a/src/pages/Client/ShoppingCart/dataClient.vue
+++ b/src/pages/Client/ShoppingCart/dataClient.vue
@@ -66,7 +66,7 @@
 
               <q-stepper-navigation>
                 <q-btn rounded @click="() => { done1 = true; step = 2; }" class="float-right q-mr-md q-mb-md" color="blue"
-                  label="Next"
+                  label="Siguiente"
                   :disable="!formClient.first_name || !formClient.first_last || !formClient.email || !formClient.adress_line2 || !formClient.city || !formClient.state_city || !formClient.zip_code || !formClient.country" />
               </q-stepper-navigation>
             </q-form>
@@ -209,8 +209,8 @@
 
             <q-stepper-navigation>
               <q-btn rounded @click="() => { done2 = true; step = 3; }" class="float-right q-mr-md q-mb-md" color="blue"
-                label="Next" />
-              <q-btn flat @click="step = 1" color="primary" rounded label="Back" class="q-mr-sm float-right" />
+                label="Siguiente" />
+              <q-btn flat @click="step = 1" color="primary" rounded label="Anterior" class="q-mr-sm float-right" />
             </q-stepper-navigation>
           </q-step>
 

--- a/src/pages/Error404.vue
+++ b/src/pages/Error404.vue
@@ -15,7 +15,7 @@
         text-color="blue"
         unelevated
         to="/"
-        label="Go Home"
+        label="Regresar"
         no-caps
       />
     </div>

--- a/src/pages/Product.vue
+++ b/src/pages/Product.vue
@@ -3,7 +3,7 @@
     <q-card style="min-width: 350px">
       <q-card-section>
         <div class="text-h6">
-          Edit product "{{ stateProduct.product.name }}"
+          Editar producto "{{ stateProduct.product.name }}"
         </div>
       </q-card-section>
 
@@ -13,23 +13,23 @@
             dense
             v-model="editForm.name"
             autofocus
-            label="Name product"
+            label="Nombre del producto"
             :rules="[(val) => !!val || 'Field is required']"
           />
           <q-input
             dense
             v-model="editForm.price"
-            label="Price product"
+            label="Precio del producto"
             :rules="[(val) => !!val || 'Field is required']"
           />
         </form>
       </q-card-section>
 
       <q-card-actions align="right" class="text-primary">
-        <q-btn flat label="Cancel" v-close-popup />
+        <q-btn flat label="Cancelar" v-close-popup />
         <q-btn
           flat
-          label="Submit"
+          label="Enviar"
           type="submit"
           v-on:click="upProduct"
           v-close-popup
@@ -40,7 +40,7 @@
 
   <section>
     <div class="q-pa-md q-gutter-sm">
-      <q-btn class="" label="Create" color="primary" @click="prompt = true" />
+      <q-btn class="" label="Crear" color="primary" @click="prompt = true" />
       <q-dialog v-model="prompt" persistent>
         <q-card style="min-width: 350px">
           <q-card-section>
@@ -66,10 +66,10 @@
           </q-card-section>
 
           <q-card-actions align="right" class="text-primary">
-            <q-btn flat label="Cancel" v-close-popup />
+            <q-btn flat label="Cancelar" v-close-popup />
             <q-btn
               flat
-              label="Submit"
+              label="Enviar"
               type="submit"
               v-on:click="createPro"
               v-close-popup

--- a/src/pages/Quotations.vue
+++ b/src/pages/Quotations.vue
@@ -91,7 +91,7 @@
                             <div class="row items-center justify-end">
                               <q-btn
                                 v-close-popup
-                                label="Close"
+                                label="Cerrar"
                                 color="primary"
                                 flat
                               />


### PR DESCRIPTION
- Standardized the application's user interface by translating remaining English labels and buttons into Spanish.
- Updated navigation labels, replacing "Dashboard" with "Panel" and "More" with "Más".
- Localized action buttons such as "GO", "Submit", "Reset", "Cancel", "Create", "Next", "Back", "Close", and "Reserve" to their Spanish equivalents.
- Added custom pagination labels (`rows-per-page-label`) to multiple data tables, including users, roles, musical genres, favorites, and client searches.
- Customized confirmation dialogs by replacing default buttons with explicit Spanish labels: "Cancelar" and "Confirmar".
- Improved text formatting and indentation in several Vue components for better code readability.
- Updated instructional and descriptive text in the About page and administrative notices to maintain consistent Spanish wording.
- Translated product management forms and dialogs, including labels for creating and editing products.
- Localized navigation controls in the shopping cart checkout process.
- Updated the 404 error page button label from "Go Home" to "Regresar".