### PR TITLE
fix: add function padCartDatePar for formatter parts of the date into…

### DIFF
--- a/src/pages/Client/Store/index.vue
+++ b/src/pages/Client/Store/index.vue
@@ -259,6 +259,9 @@ export default {
       fecha.setDate(fecha.getDate() + dias);
       return this.formatCartDate(fecha);
     },
+    padCartDatePart(value) {
+      return String(value).padStart(2, "0");
+    },
     formatCartDate(date) {
       const year = date.getFullYear();
       const month = this.padCartDatePart(date.getMonth() + 1);


### PR DESCRIPTION
This pull request adds a small utility method to the `src/pages/Client/Store/index.vue` file to improve date formatting.

* Added a new `padCartDatePart` method to pad date parts with leading zeros, which is now used in `formatCartDate` for consistent date formatting.
* The date was undefined, so if you want to add the artist into the card, the request didn't be proccess succesfully