### PR TITLE
fix: reset password fields after successful update

### DIFF
--- a/src/pages/dashboard/User/userProfile.vue
+++ b/src/pages/dashboard/User/userProfile.vue
@@ -130,6 +130,7 @@
       <div class="col-12 col-sm-8 col-md-8 q-pa-md"  :class="mode?'bg-dark':'bg-white'"  style="border-radius: 5px;">
         <div class="q-pa-md">
           <q-form
+            ref="passwordForm"
             @submit="onSubmitPassword"
             @reset="onResetPassword"
             class="q-gutter-md"
@@ -269,6 +270,7 @@ export default {
           type: "positive",
           message: `Contraseña actualizada`,
         });
+        this.clearPasswordForm();
       } catch (err) {
         if (err.response.data.message) {
           $q.notify({
@@ -317,9 +319,17 @@ export default {
       this.formUpdateMain.email = this.getMe.email;
     },
     onResetPassword() {
-      this.formUpdatePassword.newPassword = null;
-      this.formUpdatePassword.confirmPassword = null;
-      this.formUpdatePassword.currentPassword = null;
+      this.formUpdatePassword.newPassword = "";
+      this.formUpdatePassword.confirmPassword = "";
+      this.formUpdatePassword.currentPassword = "";
+    },
+    clearPasswordForm() {
+      this.onResetPassword();
+      this.$nextTick(() => {
+        if (this.$refs.passwordForm) {
+          this.$refs.passwordForm.resetValidation();
+        }
+      });
     },
     onResetImageProfile() {
       this.image_profile = null;


### PR DESCRIPTION
This pull request improves the user experience for password updates in the `userProfile.vue` component by ensuring that the password form is properly reset and its validation cleared after a successful password change. The main changes are focused on form handling and validation reset.

**Password form handling improvements:**

* Added a `ref="passwordForm"` to the password form (`<q-form>`) to allow programmatic access for resetting validation.
* Implemented a new `clearPasswordForm` method that calls `onResetPassword` and resets form validation using the form reference.
* Updated the `onResetPassword` method to reset form fields to empty strings instead of `null` for consistency.
* Ensured that after a successful password update, the password form is cleared and validation is reset by calling `clearPasswordForm`.