### PR TITLE
Implement persistent dark mode for user sessions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,9 +20,6 @@ export default defineComponent({
       api.defaults.headers.common.Authorization = "";
     }
   },
-  created() {
-    this.$q.dark.set(false);
-  },
 });
 </script>
 <style>

--- a/src/layouts/Dashboard.vue
+++ b/src/layouts/Dashboard.vue
@@ -362,10 +362,20 @@ export default {
       return this.$q.dark.isActive;
     },
   },
+  watch: {
+    getMe(user) {
+      const saved = user?.id ? localStorage.getItem(`darkMode_${user.id}`) : null;
+      const isDark = saved === 'true';
+      this.$q.dark.set(isDark);
+      this.isActiveDarkMode = isDark;
+    },
+},
+
   created() {
     this.getArtistss();
-    const saved = localStorage.getItem('darkMode');
-    const isDark = saved !== null ? saved === 'true' : this.mode;
+    const user = this.getMe;
+    const saved = user?.id ? localStorage.getItem(`darkMode_${user.id}`) : null;
+    const isDark = saved === 'true';
     this.$q.dark.set(isDark);
     this.isActiveDarkMode = isDark;
   },
@@ -384,15 +394,18 @@ export default {
       }
     },
     logout() {
+      this.$q.dark.set(false);
+      this.isActiveDarkMode = false;
       this.$store.dispatch("auth/signOut");
       const toPath = this.$route.query.to || "/";
       this.$router.push(toPath);
     },
     darkMode(val) {
       this.$q.dark.set(val);
-      localStorage.setItem('darkMode', val);
-      if (this.isAuthenticated) {
-        this.$axios.put('/api/user/dark-mode', { dark_mode: val });
+      const user = this.getMe;
+      if (user?.id) {
+        localStorage.setItem(`darkMode_${user.id}`, val);
+        this.$api.put('/api/user/dark-mode', { dark_mode: val });
       }
     },
     redirect() {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -334,9 +334,10 @@ export default {
     },
     darkMode(val) {
       this.$q.dark.set(val);
-      localStorage.setItem('darkMode', val);
-      if (this.isAuthenticated) {
-        this.$axios.put('/api/user/dark-mode', { dark_mode: val });
+      const user = this.getMe;
+      if (user?.id) {
+        localStorage.setItem(`darkMode_${user.id}`, val);
+        this.$api.put('/api/user/dark-mode', { dark_mode: val });
       }
     },
     redirectToRoute(value) {
@@ -381,8 +382,9 @@ export default {
   },
   async created() {
     this.getArtistss();
-    const saved = localStorage.getItem('darkMode');
-    const isDark = saved !== null ? saved === 'true' : this.mode;
+    const user = this.getMe;
+    const saved = user?.id ? localStorage.getItem(`darkMode_${user.id}`) : null;
+    const isDark = saved === 'true';
     this.$q.dark.set(isDark);
     this.isActiveDarkMode = isDark;
   },
@@ -393,6 +395,14 @@ export default {
 
     mode: function () {
       return this.$q.dark.isActive;
+    },
+  },
+  watch: {
+    getMe(user) {
+      const saved = user?.id ? localStorage.getItem(`darkMode_${user.id}`) : null;
+      const isDark = saved === 'true';
+      this.$q.dark.set(isDark);
+      this.isActiveDarkMode = isDark;
     },
   },
 };

--- a/src/pages/Admin/Roles/index.vue
+++ b/src/pages/Admin/Roles/index.vue
@@ -237,7 +237,6 @@
 <script>
 import { useQuasar } from "quasar";
 import { mapActions, mapState } from "vuex";
-import Swal from "sweetalert2";
 
 let $q;
 const columns = [

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -32,7 +32,7 @@ export const init = async ({ commit, dispatch }) => {
   if (token) {
     await commit("setToken", JSON.parse(token));
     api.defaults.headers.common.Authorization = "Bearer " + JSON.parse(token).access_token;
-    dispatch("getMeUser", JSON.parse(token));
+    await dispatch("getMeUser");
   } else {
     commit("removeToken");
   }


### PR DESCRIPTION
## Description
Implements a persistent dark mode preference per user on the frontend. 
Each user's dark mode state is stored independently in localStorage 
using their user ID as key (darkMode_<userId>), and synced to the 
database via the existing PUT /api/user/dark-mode endpoint.

## Changes
- App.vue: Removed forced dark.set(false) on app creation that was 
  overriding user preferences on every page load
- store/auth/actions.js: Added await to getMeUser dispatch inside init 
  action to ensure user data is available before layouts mount
- Dashboard.vue: Updated darkMode method to store preference per user ID, 
  added watch on getMe to apply saved preference when user loads, 
  added dark mode reset on logout
- MainLayout.vue: Updated darkMode method to store preference per user ID, 
  added watch on getMe to apply saved preference when user loads

## Behavior
- User selects dark/light mode → saved to localStorage with key darkMode_<userId> and synced to DB
- User logs out → UI resets to light mode
- Same user logs in again → their saved preference is restored
- Different user logs in → starts with their own preference or light mode by default