### PR TITLE
Fix/artist favorite heart style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 
 RUN npm install
 
-RUN npm install -g @quasar/cli
+RUN npm install -g @quasar/cli@1
 
 COPY . .
 

--- a/src/pages/Client/Store/index.vue
+++ b/src/pages/Client/Store/index.vue
@@ -108,7 +108,7 @@
 
                 <q-separator />
                 <q-card-actions align="right">
-                  <q-btn flat round :color="colorHeart" icon="fas fa-solid fa-heart"
+                  <q-btn flat round :color="isFavoriteArtist(props.row.id) ? 'red' : 'black'" :icon="isFavoriteArtist(props.row.id) ? 'fas fa-solid fa-heart' : 'far fa-heart'"
                     @click="addFavouriteArtist(props.row.id)" />
                   <q-btn flat round color="primary" icon="share" />
                 </q-card-actions>
@@ -152,7 +152,7 @@ export default {
       slide: 1,
       slide: ref("style"),
       listCarrito: [],
-      colorHeart: "red",
+      favoriteArtistIds: [],
       addFavourite: {
         artist_id: "",
       },
@@ -169,7 +169,7 @@ export default {
     ...mapActions("artistList", ["getArtists"]),
     ...mapActions("clientMusicalGenders", ["getMusicalGenders"]),
     ...mapActions("shoppingCard", ["create_order"]),
-    ...mapActions("favouriteArtists", ["createFavouriteArtist"]),
+    ...mapActions("favouriteArtists", ["createFavouriteArtist", "getFavouriteArtists"]),
     formatGenres(genres) {
       return genres.map((genre) => genre.name).join(", ");
     },
@@ -275,6 +275,7 @@ export default {
       this.addFavourite.artist_id = id;
       try {
         await this.createFavouriteArtist(this.addFavourite).then(() => {
+          this.toggleFavoriteArtist(id);
           this.$q.notify({
             type: "positive",
             message: this.favouriteArtists,
@@ -283,6 +284,39 @@ export default {
         this.addFavourite.artist_id = "";
       } catch (err) {
         if (err.response.data.message) {
+          $q.notify({
+            type: "negative",
+            message: err.response.data.message,
+          });
+        }
+      }
+    },
+    isFavoriteArtist(id) {
+      return this.favoriteArtistIds.includes(id);
+    },
+    toggleFavoriteArtist(id) {
+      if (this.favoriteArtistIds.includes(id)) {
+        this.favoriteArtistIds = this.favoriteArtistIds.filter((itemId) => itemId !== id);
+        return;
+      }
+      this.favoriteArtistIds.push(id);
+    },
+    syncFavoriteArtistIds() {
+      if (!Array.isArray(this.stateFavouriteArtists)) {
+        this.favoriteArtistIds = [];
+        return;
+      }
+
+      this.favoriteArtistIds = this.stateFavouriteArtists
+        .map((item) => (item && item.artist ? item.artist.id : null))
+        .filter((id) => id !== null && id !== undefined);
+    },
+    async loadFavouriteArtists() {
+      try {
+        await this.getFavouriteArtists();
+        this.syncFavoriteArtistIds();
+      } catch (err) {
+        if (err.response && err.response.data && err.response.data.message) {
           $q.notify({
             type: "negative",
             message: err.response.data.message,
@@ -338,6 +372,7 @@ export default {
   },
   computed: {
     ...mapGetters("artistList", ["stateArtistList"]),
+    ...mapGetters("favouriteArtists", ["stateFavouriteArtists"]),
     ...mapState({
       clientMusicalGenders: (state) =>
         state.clientMusicalGenders.musicalGenders,
@@ -349,6 +384,7 @@ export default {
   created() {
     this.gettMusicalGenders();
     this.getArtistss();
+    this.loadFavouriteArtists();
     this.slug = this.$route.params.slug;
   },
   mounted() {


### PR DESCRIPTION
This pull request enhances the favorite artist functionality in the client store page, improving both the UI and the underlying state management. The main changes include updating how favorite artists are tracked and displayed, synchronizing the favorites with the backend, and refining the favorite button's behavior.

**Favorite Artist Functionality Improvements:**

- The favorite artist button now visually reflects whether an artist is a favorite by changing its color and icon dynamically based on the artist's status (`isFavoriteArtist`).
- Added local state management for favorite artist IDs (`favoriteArtistIds`) and utility methods (`isFavoriteArtist`, `toggleFavoriteArtist`, `syncFavoriteArtistIds`) to track and update favorites efficiently. [[1]](diffhunk://#diff-80cbfb16fa17280041f196e0bba971a355c7a5e39e5945180a286847e6fb0badL155-R155) [[2]](diffhunk://#diff-80cbfb16fa17280041f196e0bba971a355c7a5e39e5945180a286847e6fb0badR294-R326)
- Synchronized the local favorite artist list with the backend by fetching favorites on component creation and updating local state accordingly (`loadFavouriteArtists`, `syncFavoriteArtistIds`). [[1]](diffhunk://#diff-80cbfb16fa17280041f196e0bba971a355c7a5e39e5945180a286847e6fb0badL172-R172) [[2]](diffhunk://#diff-80cbfb16fa17280041f196e0bba971a355c7a5e39e5945180a286847e6fb0badR375) [[3]](diffhunk://#diff-80cbfb16fa17280041f196e0bba971a355c7a5e39e5945180a286847e6fb0badR387)
- Updated the favorite artist action to immediately reflect changes in the UI by toggling the favorite state after a successful API call.

**Dependency Management:**

- Updated the global Quasar CLI installation in the `Dockerfile` to use a specific version (`@quasar/cli@1`) for improved build consistency.