### PR TITLE
fix: update favorite artist functionality with dynamic heart icon and…

### DIFF
--- a/src/pages/Client/MusicalGenders/search.vue
+++ b/src/pages/Client/MusicalGenders/search.vue
@@ -152,8 +152,8 @@
                 <q-btn
                   flat
                   round
-                  :color="colorHeart"
-                  icon="fas fa-solid fa-heart"
+                  :color="isFavoriteArtist(props.row.id) ? 'red' : 'black'"
+                  :icon="isFavoriteArtist(props.row.id) ? 'fas fa-solid fa-heart' : 'far fa-heart'"
                   @click="addFavouriteArtist(props.row.id)"
                 />
                 <q-btn flat round color="primary" icon="share" />
@@ -187,7 +187,7 @@
 
 <script>
 import { useQuasar, QSpinnerGears, QSpinnerAudio } from "quasar";
-import { mapActions, mapState } from "vuex";
+import { mapActions, mapGetters, mapState } from "vuex";
 import { ref } from "vue";
 
 let $q;
@@ -204,7 +204,7 @@ export default {
       showResult: null,
       starts: 4,
       listCarrito: [],
-      colorHeart: "red",
+      favoriteArtistIds: [],
       addFavourite: {
         artist_id: "",
       },
@@ -213,7 +213,7 @@ export default {
   methods: {
     ...mapActions("clientMusicalGenders", ["getMusicalGendersBySlug"]),
     ...mapActions("shoppingCard", ["create_order"]),
-    ...mapActions("favouriteArtists", ["createFavouriteArtist"]),
+    ...mapActions("favouriteArtists", ["createFavouriteArtist", "getFavouriteArtists"]),
     async gettMusicalGendersBySlug() {
       try {
         await this.getMusicalGendersBySlug(this.slug).then(() => {
@@ -310,6 +310,7 @@ export default {
       this.addFavourite.artist_id = id;
       try {
         await this.createFavouriteArtist(this.addFavourite).then(() => {
+          this.toggleFavoriteArtist(id);
           this.$q.notify({
             type: "positive",
             message: this.favouriteArtists,
@@ -325,12 +326,47 @@ export default {
         }
       }
     },
+    isFavoriteArtist(id) {
+      return this.favoriteArtistIds.includes(id);
+    },
+    toggleFavoriteArtist(id) {
+      if (this.favoriteArtistIds.includes(id)) {
+        this.favoriteArtistIds = this.favoriteArtistIds.filter((itemId) => itemId !== id);
+        return;
+      }
+      this.favoriteArtistIds.push(id);
+    },
+    syncFavoriteArtistIds() {
+      if (!Array.isArray(this.stateFavouriteArtists)) {
+        this.favoriteArtistIds = [];
+        return;
+      }
+
+      this.favoriteArtistIds = this.stateFavouriteArtists
+        .map((item) => (item && item.artist ? item.artist.id : null))
+        .filter((id) => id !== null && id !== undefined);
+    },
+    async loadFavouriteArtists() {
+      try {
+        await this.getFavouriteArtists();
+        this.syncFavoriteArtistIds();
+      } catch (err) {
+        if (err.response && err.response.data && err.response.data.message) {
+          $q.notify({
+            type: "negative",
+            message: err.response.data.message,
+          });
+        }
+      }
+    },
   },
   created() {
     this.slug = this.$route.params.slug;
     this.gettMusicalGendersBySlug();
+    this.loadFavouriteArtists();
   },
   computed: {
+    ...mapGetters("favouriteArtists", ["stateFavouriteArtists"]),
     ...mapState({
       clientMusicalGenders: (state) =>
         state.clientMusicalGenders.artistsGenders,


### PR DESCRIPTION
Implemented dynamic favorite artist management functionality. This updates the UI reactively when a user marks or unmarks an artist as a favorite, and ensures data persistence by fetching the user's favorite artists on component initialization.

## Changes Made
*   **Template:** Updated the favorite button (`q-btn`) to conditionally render its color ('red' vs 'black') and icon (solid vs regular heart) based on the artist's favorite status.
*   **Vuex Integration:** Mapped the `getFavouriteArtists` action and the `stateFavouriteArtists` getter.
*   **State Management & Synchronization:** 
    *   Added `favoriteArtistIds` local state array.
    *   Implemented `isFavoriteArtist(id)` to check if an artist is favorited.
    *   Implemented `toggleFavoriteArtist(id)` to update the local UI state reactively after a successful API call.
    *   Implemented `syncFavoriteArtistIds()` to map and filter backend data safely.
*   **Lifecycle Hooks:** Added `loadFavouriteArtists()` inside the `created` hook to fetch and sync the initial state on mount.