### PR TITLE
Format created_at date and sort admin tables by ID descending

### DIFF
--- a/src/pages/Admin/MusicalGenders/index.vue
+++ b/src/pages/Admin/MusicalGenders/index.vue
@@ -48,7 +48,7 @@
             {{ props.row.description }}
           </q-td>
           <q-td key="created_at" :props="props">
-            {{ props.row.created_at }}
+            {{ formatDate(props.row.created_at) }}
           </q-td>
           <q-td key="options" :props="props">
             <q-btn
@@ -320,6 +320,11 @@ export default {
       filter: "",
       formEdit: false,
       formCreate: false,
+      pagination: {
+        sortBy: "created_at",
+        descending: true,
+        rowsPerPage: 10,
+      },
       form: {
         id: "",
         name: "",
@@ -381,6 +386,14 @@ export default {
     ...mapActions("musicalGenders", ["deleteMusicalGender"]),
     ...mapActions("musicalGenders", ["updateMusicalGender"]),
 
+    formatDate(date) {
+      if (!date) return "";
+      const d = new Date(date);
+      const day = String(d.getDate()).padStart(2, "0");
+      const month = String(d.getMonth() + 1).padStart(2, "0");
+      const year = String(d.getFullYear()).slice(-2);
+      return `${day}/${month}/${year}`;
+    },
     async gettMusicalGenders() {
       try {
         await this.getMusicalGenders();
@@ -500,7 +513,7 @@ export default {
     $q = useQuasar();
   },
   beforeUpdate() {
-    this.rows = this.musicalGenders;
+    this.rows = [...this.musicalGenders].sort((a, b) => b.id - a.id);
     this.loading = false;
   },
 };

--- a/src/pages/Admin/Roles/index.vue
+++ b/src/pages/Admin/Roles/index.vue
@@ -47,7 +47,7 @@
             {{ props.row.description }}
           </q-td>
           <q-td key="created_at" :props="props">
-            {{ props.row.created_at }}
+            {{ formatDate(props.row.created_at) }}
           </q-td>
           <q-td key="options" :props="props">
             <q-btn
@@ -288,6 +288,11 @@ export default {
       filter: "",
       formEdit: false,
       formCreate: false,
+      pagination: {
+        sortBy: "created_at",
+        descending: true,
+        rowsPerPage: 10,
+      },
       form: {
         id: "",
         name: "",
@@ -302,6 +307,14 @@ export default {
     ...mapActions("roles", ["getPermissions"]),
     ...mapActions("roles", ["updateRole"]),
     ...mapActions("roles", ["createRole"]),
+    formatDate(date) {
+      if (!date) return "";
+      const d = new Date(date);
+      const day = String(d.getDate()).padStart(2, "0");
+      const month = String(d.getMonth() + 1).padStart(2, "0");
+      const year = String(d.getFullYear()).slice(-2);
+      return `${day}/${month}/${year}`;
+    },
     async gettRoles() {
       try {
         await this.getRoles();
@@ -443,7 +456,7 @@ export default {
     $q = useQuasar();
   },
   beforeUpdate() {
-    this.rows = this.roles;
+    this.rows = [...this.roles].sort((a, b) => b.id - a.id);
     this.loading = false;
   },
 };

--- a/src/pages/Admin/Users/index.vue
+++ b/src/pages/Admin/Users/index.vue
@@ -48,7 +48,7 @@
             {{ props.row.role_name }}
           </q-td>
           <q-td key="created_at" :props="props">
-            {{ props.row.created_at }}
+            {{ formatDate(props.row.created_at) }}
           </q-td>
           <q-td key="options" :props="props">
             <q-btn
@@ -289,6 +289,11 @@ export default {
       rows,
       filter: "",
       formCreate: false,
+      pagination: {
+        sortBy: "created_at",
+        descending: true,
+        rowsPerPage: 10,
+      },
       formEdit: false,
       form: {
         id: "",
@@ -305,6 +310,14 @@ export default {
     ...mapActions("users", ["deleteUser"]),
     ...mapActions("users", ["updateUser"]),
     ...mapActions("roles", ["getRoles"]),
+    formatDate(date) {
+      if (!date) return "";
+      const d = new Date(date);
+      const day = String(d.getDate()).padStart(2, "0");
+      const month = String(d.getMonth() + 1).padStart(2, "0");
+      const year = String(d.getFullYear()).slice(-2);
+      return `${day}/${month}/${year}`;
+    },
     async gettUsers() {
       try {
         await this.getUsers();
@@ -472,7 +485,7 @@ export default {
     $q = useQuasar();
   },
   beforeUpdate() {
-    this.rows = this.users;
+    this.rows = [...this.users].sort((a, b) => b.id - a.id);
     this.loading = false;
   },
 };


### PR DESCRIPTION
## Changes
- Format `created_at` column from raw timestamp to `dd/mm/yy` in the following admin tables:
  - Users
  - Roles
  - Musical Genders
- Sort all three tables by `id` descending so the most recently added records appear at the top

## Files modified
- `src/pages/Admin/Users/index.vue`
- `src/pages/Admin/Roles/index.vue`
- `src/pages/Admin/MusicalGenders/index.vue`

## Notes
- No backend changes required
- No existing functionality was affected