### PR TITLE
Feature: Improve Artist Navigation and Sharing Actions

### DIFF
--- a/src/layouts/Dashboard.vue
+++ b/src/layouts/Dashboard.vue
@@ -200,7 +200,7 @@
             <q-item-section> Generos Musicales</q-item-section>
           </q-item>
 
-          <q-item clickable v-ripple to="/" v-if="$can('create-card')">
+          <q-item clickable v-ripple to="/artist-list" v-if="$can('create-card')">
             <q-item-section avatar>
               <q-icon name="fas fa-solid fa-tags" />
             </q-item-section>

--- a/src/pages/Client/Store/index.vue
+++ b/src/pages/Client/Store/index.vue
@@ -110,7 +110,7 @@
                 <q-card-actions align="right">
                   <q-btn flat round :color="isFavoriteArtist(props.row.id) ? 'red' : 'black'" :icon="isFavoriteArtist(props.row.id) ? 'fas fa-solid fa-heart' : 'far fa-heart'"
                     @click="addFavouriteArtist(props.row.id)" />
-                  <q-btn flat round color="primary" icon="share" />
+                  <q-btn flat round color="primary" icon="share" @click="copyArtistLink(props.row.slug, props.row.musical_genders[0].slug)" />
                 </q-card-actions>
               </q-card>
             </div>
@@ -290,6 +290,12 @@ export default {
           });
         }
       }
+    },
+    copyArtistLink(artistSlug, genreSlug) {
+      const link = `${window.location.origin}/client/musical-genders/${genreSlug}/${artistSlug}`;
+      navigator.clipboard.writeText(link).then(() => {
+        this.$q.notify({ type: 'positive', message: 'Link copiado al portapapeles' });
+      });
     },
     isFavoriteArtist(id) {
       return this.favoriteArtistIds.includes(id);


### PR DESCRIPTION

## Summary

This PR improves navigation behavior inside the dashboard and adds a share functionality for artist cards in the client store.

Users can now:

* Navigate correctly to the artist list from the dashboard menu.
* Share artist profile links directly from the store view.

## Changes Made

### Dashboard Navigation

Updated the dashboard sidebar navigation item:

* Changed the route from `/` to `/artist-list`
* Ensures users with the `create-card` permission are redirected to the correct artist listing page.

### Artist Share Feature

Added a share/copy link action in the client store artist cards:

* The share button now copies the artist public URL to the clipboard.
* The generated link includes:

  * Musical genre slug
  * Artist slug
* Added success notification after copying the link.

### New Method Added

Created `copyArtistLink()` method to:

* Generate the public artist URL dynamically
* Copy the URL using `navigator.clipboard.writeText`
* Display a Quasar positive notification confirmation

## Example Generated URL

```txt
/client/musical-genders/{genreSlug}/{artistSlug}
```

## Files Modified

* `src/layouts/Dashboard.vue`
* `src/pages/Client/Store/index.vue`

