### PR TITLE
dynamic star ratings in store and search views, fix Vue Router bug, a…

### DIFF
--- a/src/pages/ArtistList.vue
+++ b/src/pages/ArtistList.vue
@@ -68,7 +68,9 @@
         <template v-slot:item="props">
           <div class="q-pa-xs col-xs-12 col-sm-6 col-md-4">
             
-            <q-card class="my-card q-ma-sm" v-if="skeleton == false">
+            <q-skeleton class="q-ma-sm" height="350px" v-show="skeleton" />
+            
+            <q-card class="my-card q-ma-sm" v-show="!skeleton">
               <q-img :src="props.row.image" class="imageArtist" />
 
               <q-card-section>
@@ -88,9 +90,13 @@
                 </div>
 
                 <q-rating
-                  v-model="starts"
+                  :model-value="parseFloat(props.row?.ratings_avg_rating || 0)"
                   :max="5"
                   size="32px"
+                  color="yellow"
+                  icon="star_border"
+                  icon-selected="star"
+                  icon-half="star_half"
                   no-dimming
                   readonly
                 />

--- a/src/pages/Client/MusicalGenders/search.vue
+++ b/src/pages/Client/MusicalGenders/search.vue
@@ -96,7 +96,7 @@
               height="350px"
               v-if="skeleton == true"
             />
-            <q-card class="my-card q-ma-sm" v-if="skeleton == false">
+            <q-card class="my-card q-ma-sm" v-show="!skeleton">
               <q-img :src="props.row.image" class="imageArtist" />
 
               <q-card-section>
@@ -126,9 +126,13 @@
                 </div>
 
                 <q-rating
-                  v-model="starts"
+                  :model-value="parseFloat(props.row?.ratings_avg_rating || 0)"
                   :max="5"
                   size="32px"
+                  color="yellow"
+                  icon="star_border"
+                  icon-selected="star"
+                  icon-half="star_half"
                   no-dimming
                   readonly
                 />
@@ -202,7 +206,6 @@ export default {
       slug: null,
       skeleton: true,
       showResult: null,
-      starts: 4,
       listCarrito: [],
       favoriteArtistIds: [],
       addFavourite: {

--- a/src/pages/Client/MusicalGenders/show.vue
+++ b/src/pages/Client/MusicalGenders/show.vue
@@ -51,15 +51,13 @@
               <span class="text-weight-regular">{{ artist.members }}</span>
             </p>
             <q-rating
-              v-model="start"
-              max="5"
-              size="1.5em"
-              color="yellow"
-              icon="star_border"
-              icon-selected="star"
-              icon-half="star_half"
-              no-dimming
-              readonly
+            v-model="userRating"
+            max="5"
+            size="1.5em"
+            color="yellow"
+            icon="star_border"
+            icon-selected="star"
+            @update:model-value="sendRating"
             />
             <div class="row">
               <div class="col-6">
@@ -253,7 +251,7 @@ export default {
   name: "Slug",
   data() {
     return {
-      start: 4,
+      userRating: 0,
       slug: "",
       slugMG: "",
       loadInformation: true,
@@ -275,16 +273,41 @@ export default {
     };
   },
   methods: {
+    async sendRating(value) {
+      try {
+        await this.$api.post(`/api/client/artists/${this.artist.id}/rate`, {
+          rating: value
+        });
+        $q.notify({
+          type: "positive",
+          message: "¡Calificación guardada con éxito!"
+        });
+      } catch (err) {
+        console.error("Error de validación:", err.response.data.errors);
+        
+        $q.notify({
+          type: "negative",
+          message: "Error al guardar la calificación"
+        });
+      }
+    },
     ...mapActions("clientMusicalGenders", ["getArtistBySlug"]),
     ...mapActions("shoppingCard", ["updateItemShoppingCart"]),
     ...mapActions("shoppingCard", ["create_order"]),
     async gettArtistBySlug() {
       try {
-        await this.getArtistBySlug(this.slug).then(() => {
+        await this.getArtistBySlug(this.slug).then(async () => {
           this.loadInformation = false;
           const link = this.artist.manager.phone.replace(/\s+/g, "");
           this.linkWhatsApp = `https://wa.me/${link}?text=Hola%20me%20interesa%20su%20sevicios`;
           this.linkCorreo = `mailto:${this.artist.manager.email}`;
+          try {
+            const res = await this.$api.get(`/api/client/artists/${this.artist.id}/my-rating`);
+            
+            this.userRating = res.data.rating;
+          } catch (e) {
+            console.error("No se pudo cargar la calificación previa", e);
+          }
         });
       } catch (err) {
         if (err.response.data.message) {

--- a/src/pages/Client/Store/index.vue
+++ b/src/pages/Client/Store/index.vue
@@ -68,7 +68,7 @@
           :rows-per-page-label="'Artistas por página:'" :rows-per-page-options="[6, 12, 18, 24, 30]">
           <template v-slot:item="props">
             <div class="q-pa-xs col-xs-12 col-sm-6 col-md-4">
-              <q-card class="my-card q-ma-sm" v-if="skeleton == false">
+            <q-card class="my-card q-ma-sm" v-show="!skeleton">
                 <q-img :src="props.row.image" class="imageArtist" />
 
                 <q-card-section>
@@ -76,16 +76,27 @@
                     style="top: 0; right: 12px; transform: translateY(-50%)" v-on:click="onSendOrder(props.row)" />
                   <div class="row no-wrap items-center">
                     <div class="col text-h6 ellipsis search text-weight-regular"
-                      @click="props.row.slug, props.row.musical_genders[0].slug">
+                      @click="search(props.row.slug, props.row.musical_genders[0].slug)">
                       {{ props.row.name }}
-                    </div>
+                    </div> 
                     <div class="col-auto text-grey text-caption q-pt-md row no-wrap items-center">
                       <q-icon name="map" />
                       <small>{{ props.row.zone }}</small>
                     </div>
                   </div>
 
-                  <q-rating v-model="starts" :max="5" size="32px" no-dimming readonly />
+                  <q-rating 
+                    :model-value="parseFloat(props.row?.ratings_avg_rating || 0)" 
+                    :max="5" 
+                    size="32px" 
+                    color="yellow"
+                    icon="star_border"
+                    icon-selected="star"
+                    icon-half="star_half"
+                    no-dimming 
+                    readonly 
+                  />
+
                 </q-card-section>
 
                 <q-card-section class="q-pt-none">
@@ -147,9 +158,7 @@ export default {
       columns,
       slug: null,
       skeleton: true,
-      starts: 4,
       searchSlug: null,
-      slide: 1,
       slide: ref("style"),
       listCarrito: [],
       favoriteArtistIds: [],
@@ -173,6 +182,16 @@ export default {
     formatGenres(genres) {
       return genres.map((genre) => genre.name).join(", ");
     },
+    search(slug, slugmg) {
+      this.$router.push({
+        name: "client.view-group-by-gender-slug",
+        params: {
+          slugMG: slugmg,
+          slugA: slug,
+        },
+      });
+    },
+
     async getArtistss() {
       try {
         await this.getArtists().then(() => {

--- a/src/pages/Client/Store/index.vue
+++ b/src/pages/Client/Store/index.vue
@@ -68,7 +68,7 @@
           :rows-per-page-label="'Artistas por página:'" :rows-per-page-options="[6, 12, 18, 24, 30]">
           <template v-slot:item="props">
             <div class="q-pa-xs col-xs-12 col-sm-6 col-md-4">
-            <q-card class="my-card q-ma-sm" v-show="!skeleton">
+              <q-card class="my-card q-ma-sm" v-show="!skeleton">
                 <q-img :src="props.row.image" class="imageArtist" />
 
                 <q-card-section>


### PR DESCRIPTION
## Summary
Implemented a complete artist rating feature across the client and artist listing pages, replacing static ratings with dynamic average ratings from the API. Improved loading behavior by using skeleton placeholders and added navigation enhancements for artist cards.

## Changes Made

### Dynamic Average Ratings
- Replaced hardcoded rating values (`starts` and `start`) with dynamic values using `ratings_avg_rating`.
- Configured `q-rating` components to display:
  - Yellow stars
  - Empty star icons (`star_border`)
  - Filled star icons (`star`)
  - Half-star icons (`star_half`)
- Applied these changes to:
  - `ArtistList.vue`
  - `Client/MusicalGenders/search.vue`
  - `Client/Store/index.vue`

### User Rating Functionality
- Added an interactive rating system in `Client/MusicalGenders/show.vue`.
- Replaced the static readonly rating component with a user-editable rating bound to `userRating`.
- Implemented `sendRating()` to:
  - Submit the selected rating to the API endpoint `/api/client/artists/{id}/rate`
  - Show a success notification when the rating is saved
  - Show an error notification if the request fails
- Added logic to retrieve the authenticated user's previous rating from `/api/client/artists/{id}/my-rating` and preload it into the rating component.

### Skeleton Loading Improvements
- Added a `q-skeleton` placeholder to `ArtistList.vue`.
- Replaced `v-if="skeleton == false"` with `v-show="!skeleton"` in several pages to improve rendering performance and preserve component state during loading.

### Navigation Fixes
- Added a `search(slug, slugmg)` method in `Client/Store/index.vue`.
- Updated artist name click events to correctly navigate to the artist detail page using Vue Router.

### Code Cleanup
- Removed unused data properties:
  - `starts`
  - `start`
- Simplified component state by keeping only the necessary reactive variables.