### PR TITLE
Feature/add field roles to email

### DIFF
--- a/src/pages/Admin/EmailSubscribedUsers/index.vue
+++ b/src/pages/Admin/EmailSubscribedUsers/index.vue
@@ -100,9 +100,17 @@ export default {
                     message: `Se envió el email de forma correcta`,
                 });
             } catch (err) {
+                const backendMessage =
+                    err?.response?.data?.message ||
+                    err?.response?.data?.errors?.role_ids?.[0] ||
+                    err?.response?.data?.errors?.subject?.[0] ||
+                    err?.response?.data?.errors?.content?.[0] ||
+                    err?.message ||
+                    "Algo salió mal, vuelve a intentarlo más tarde";
+
                 $q.notify({
                 type: "negative",
-                message: `Algo salió mal, vuelve a intentarlo más tarde ${err}`
+                message: backendMessage
             });
         }
     },

--- a/src/pages/Admin/EmailSubscribedUsers/index.vue
+++ b/src/pages/Admin/EmailSubscribedUsers/index.vue
@@ -2,6 +2,23 @@
     <q-card style="margin-top:-50px; width: 100%; padding: 10px;">
         <q-card-section>
         <h3 class="q-mb-md" style="margin-bottom: 35px;">Newsletter</h3>
+            <q-select
+            v-model="selectedRoles"
+            :options="rolesOptions"
+            label="Enviar a roles"
+            dense
+            outlined
+            multiple
+            use-chips
+            emit-value
+            map-options
+            option-label="name"
+            option-value="id"
+            clearable
+            hint="Selecciona uno o varios roles que recibirán el correo"
+            class="q-mb-md"
+            ></q-select>
+
             <q-input
             style="margin-bottom: 15px;"
             label="Asunto"
@@ -36,7 +53,6 @@
 </template>
 
 <script>
-import { ref } from 'vue'
 import { useQuasar } from "quasar";
 import { mapActions, mapGetters } from "vuex";
 
@@ -44,21 +60,41 @@ let $q;
 export default {
     data() {
         return {
-            emailSubject: ref('Ingresa el Asunto del Correo'),
-            emailContent: ref('Ingresa el Contenido del Correo'),
+            emailSubject: '',
+            emailContent: '',
+            selectedRoles: [],
         };
     },
     methods: {
+        ...mapActions("roles", ["getRoles"]),
         ...mapActions("UsersSuscribe", ["sendEmail"]),
         async sendEmails() {
             try {
+                if (!this.selectedRoles.length) {
+                    $q.notify({
+                        type: "negative",
+                        message: "Selecciona al menos un rol antes de enviar el correo",
+                    });
+                    return;
+                }
+
+                if (!this.emailSubject.trim() || !this.emailContent.trim()) {
+                    $q.notify({
+                        type: "negative",
+                        message: "El asunto y el contenido no pueden quedar vacíos",
+                    });
+                    return;
+                }
+
                 const jsonData = {
-                    subject: this.emailSubject,
-                    content: this.emailContent,
+                    subject: this.emailSubject.trim(),
+                    content: this.emailContent.trim(),
+                    role_ids: this.selectedRoles,
                 };
                 await this.sendEmail(jsonData);
                 this.emailSubject = '';
                 this.emailContent = '';
+                this.selectedRoles = [];
                 $q.notify({
                     type: "positive",
                     message: `Se envió el email de forma correcta`,
@@ -72,10 +108,17 @@ export default {
     },
 },
     computed: {
+        ...mapGetters("roles", ["stateRoles"]),
         ...mapGetters("UsersSuscribe", ["stateEmails"]),
+        rolesOptions() {
+            return Array.isArray(this.stateRoles) ? this.stateRoles : [];
+        },
         mode: function () {
         return this.$q.dark.isActive;
         },
+    },
+    created() {
+        this.getRoles();
     },
     mounted() {
         $q = useQuasar();


### PR DESCRIPTION
This pull request enhances the newsletter email feature for administrators by allowing them to target emails to specific user roles, improving both functionality and user experience. The most important changes are grouped below:

**Role-based Email Targeting:**

* Added a `q-select` input to the UI, allowing admins to select one or more roles to receive the newsletter. The selection is displayed as chips and is fully integrated with the available roles from the store. (`src/pages/Admin/EmailSubscribedUsers/index.vue`)
* Fetched available roles on component creation and populated the select options using the Vuex `roles` module. (`src/pages/Admin/EmailSubscribedUsers/index.vue`)

**Validation and Email Sending Logic:**

* Updated the `sendEmails` method to require at least one role to be selected and to validate that both the subject and content are not empty before sending. Improved notification messages to provide more specific feedback based on backend responses. (`src/pages/Admin/EmailSubscribedUsers/index.vue`)
* Modified the email payload to include the selected role IDs (`role_ids`) and reset all form fields after a successful send. (`src/pages/Admin/EmailSubscribedUsers/index.vue`)

**Code Cleanup:**

* Removed unnecessary use of `ref` for form fields and switched to plain strings for simpler state management. (`src/pages/Admin/EmailSubscribedUsers/index.vue`)