### PR TITLE
replace legacy brand name with Vibeer across UI components

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -105,7 +105,7 @@
               color="primary"
               size="40px"
             ></q-icon>
-            <span class="q-ml-sm">Música GSM</span>
+            <span class="q-ml-sm">Vibeer</span>
           </q-toolbar-title>
         </q-toolbar>
 
@@ -202,7 +202,7 @@
           <div class="col-12">
             <div class="row items-center q-ma-lg justify-center">
               <div class="col-12 col-xs-12 col-sm-3 col-md-3">
-                <p class="text-weight-bold">Música GSM</p>
+                <p class="text-weight-bold">Vibeer</p>
                 <p>
                   Plataforma dedicada a conectar artistas musicales con clientes
                   que buscan el mejor talento para sus eventos.

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -139,7 +139,7 @@
           <q-icon name="health_and_safety" color="primary" />
         </template>
         <span class="text-weight-bold text-info">Reserva con Seguridad</span>,
-        si cancelas por COVID-19 te devolvemos el dinero. Musica GSM vela por
+        si cancelas por COVID-19 te devolvemos el dinero. Vibeer vela por
         <span class="text-weight-bold"> tu seguridad y la de los tuyos</span>
       </q-banner>
     </div>


### PR DESCRIPTION
- Replaced the application name **"Música GSM"** with **"Vibeer"** across the main layout and homepage.
- Updated the toolbar title in `MainLayout.vue` to display the new brand name.
- Updated the footer/company section in `MainLayout.vue` to reflect the new branding.
- Modified the security banner message in `Index.vue` to reference **Vibeer** instead of **Música GSM**.

### Files Modified

- `src/layouts/MainLayout.vue`
- `src/pages/Index.vue`