### PR TITLE
Improve new artist form texts and textarea UX

### DIFF
--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -26,14 +26,14 @@
             </p>
             <p class="text-center q-mb-sm text-weight-bold">
               Disfruta la nueva experiencia de contratación de servicios
-              musicales rapida y segura.
+              musicales rápida y segura.
             </p>
 
             <div class="row content-center">
               <q-input
                 v-model="formCreate.name"
                 class="col-12 col-sm-5 q-ma-sm"
-                label="Nombre del grupo o artistico"
+                label="Nombre del grupo o artístico"
                 hint="Nombre completo del grupo o del artista"
                 lazy-rules
                 :rules="[
@@ -44,7 +44,7 @@
                 v-model="formCreate.members"
                 class="col-12 col-sm-5 q-ma-sm"
                 label="Integrantes"
-                hint="Numero de integrantes"
+                hint="Número de integrantes"
                 type="number"
                 lazy-rules
                 :rules="[
@@ -55,7 +55,7 @@
               <q-input
                 v-model="formCreate.history"
                 type="textarea"
-                style="height: 50px"
+                autogrow
                 class="col-12 col-sm-10 q-ma-sm"
                 label="Historia del grupo"
                 hint="Describe las historia de tu grupo o tu como solista, esto se le muestra al usuario "
@@ -448,7 +448,7 @@
             </p>
             <p class="text-center q-mb-sm text-weight-bold">
               Disfruta la nueva experiencia de contratación de servicios
-              musicales rapida y segura.
+              musicales rápida y segura.
             </p>
 
             <div class="row content-center">
@@ -466,7 +466,7 @@
                 v-model="formCreate.members"
                 class="col-12 col-sm-5 q-ma-sm"
                 label="Integrantes"
-                hint="Numero de integrantes"
+                hint="Número de integrantes"
                 type="number"
                 lazy-rules
                 :rules="[(val) => (val && val > 0) || 'Por favor ingresa algo']"
@@ -475,7 +475,7 @@
               <q-input
                 v-model="formCreate.history"
                 type="textarea"
-                style="height: 50px"
+                autogrow
                 class="col-12 col-sm-10 q-ma-sm"
                 label="Historia del grupo"
                 hint="Describe las historia de tu grupo o tu como solista, esto se le muestra al usuario "


### PR DESCRIPTION
## Summary
This PR improves the artist registration form by correcting text accents and enhancing the textarea user experience.

## Changes

### Text Improvements
Updated labels and descriptions to use proper Spanish accents:

- "rapida" → "rápida"
- "artistico" → "artístico"
- "Numero" → "Número"

### Form UX Improvements
Improved the artist history textarea behavior by replacing the fixed height style with:

- `autogrow`

This allows the textarea to expand dynamically based on the content entered by the user.

## Why
Previously:
- Some labels and descriptions contained spelling/accent issues.
- The history textarea had a fixed height, making longer descriptions less comfortable to write.

These changes improve readability and provide a better form experience for artists creating their profiles.
