### PR TITLE
fix: Button fav fixed. Now the client rol can add artists into the li…

### DIFF
--- a/src/pages/Client/MusicalGenders/show.vue
+++ b/src/pages/Client/MusicalGenders/show.vue
@@ -288,14 +288,14 @@ export default {
         await this.$api.post(`/api/client/artists/${this.artist.id}/rate`, {
           rating: value
         });
-        $q.notify({
+          this.$q.notify({
           type: "positive",
           message: "¡Calificación guardada con éxito!"
         });
       } catch (err) {
         console.error("Error de validación:", err.response.data.errors);
         
-        $q.notify({
+          this.$q.notify({
           type: "negative",
           message: "Error al guardar la calificación"
         });
@@ -312,17 +312,16 @@ export default {
 
       this.addFavourite.artist_id = id;
       try {
-        await this.createFavouriteArtist(this.addFavourite).then(() => {
-          this.toggleFavoriteArtist(id);
-          this.$q.notify({
-            type: "positive",
-            message: "Agregado a Favoritos",
-          });
+        await this.createFavouriteArtist(this.addFavourite);
+        this.toggleFavoriteArtist(id);
+        this.$q.notify({
+          type: "positive",
+          message: "Agregado a Favoritos",
         });
         this.addFavourite.artist_id = "";
       } catch (err) {
         if (err.response && err.response.data && err.response.data.message) {
-          $q.notify({
+             this.$q.notify({
             type: "negative",
             message: err.response.data.message,
           });
@@ -346,7 +345,7 @@ export default {
         });
       } catch (err) {
         if (err.response.data.message) {
-          $q.notify({
+            this.$q.notify({
             type: "negative",
             message: err.response.data.message,
           });
@@ -376,7 +375,7 @@ export default {
       }
     },
     onSendOrder(artist) {
-      $q.notify({
+      this.$q.notify({
         spinner: QSpinnerGears,
         message: "Agregando al carrito...",
         timeout: 200,
@@ -389,7 +388,7 @@ export default {
       formData.append("order_date_start", this.printDateStart());
       formData.append("order_date_finish", this.printDateFinish());
       this.create_order(formData).then(() => {
-        $q.notify({
+        this.$q.notify({
           type: "positive",
           spinner: QSpinnerAudio,
           message: "Artista agregado",
@@ -429,7 +428,7 @@ export default {
         this.syncFavoriteArtistIds();
       } catch (err) {
         if (err.response && err.response.data && err.response.data.message) {
-          $q.notify({
+            this.$q.notify({
             type: "negative",
             message: err.response.data.message,
           });

--- a/src/pages/Client/MusicalGenders/show.vue
+++ b/src/pages/Client/MusicalGenders/show.vue
@@ -69,7 +69,13 @@
               </div>
               <div class="col-6">
                 <div align="right">
-                  <q-btn flat round color="red" icon="favorite" />
+                  <q-btn
+                    flat
+                    round
+                    :color="isFavoriteArtist(artist.id) ? 'red' : 'black'"
+                    :icon="isFavoriteArtist(artist.id) ? 'fas fa-solid fa-heart' : 'far fa-heart'"
+                    @click="addFavouriteArtist(artist.id)"
+                  />
                   <q-btn flat round color="white" icon="share" @click="copyArtistLink()" />
                 </div>
               </div>
@@ -265,6 +271,10 @@ export default {
       showGallery: null,
       showInfo: null,
       listCart: [],
+      favoriteArtistIds: [],
+      addFavourite: {
+        artist_id: "",
+      },
       hours: 1,
       item: {
         artist_id: "",
@@ -294,6 +304,31 @@ export default {
     ...mapActions("clientMusicalGenders", ["getArtistBySlug"]),
     ...mapActions("shoppingCard", ["updateItemShoppingCart"]),
     ...mapActions("shoppingCard", ["create_order"]),
+    ...mapActions("favouriteArtists", ["createFavouriteArtist", "getFavouriteArtists"]),
+    async addFavouriteArtist(id) {
+      if (!id || this.isFavoriteArtist(id)) {
+        return;
+      }
+
+      this.addFavourite.artist_id = id;
+      try {
+        await this.createFavouriteArtist(this.addFavourite).then(() => {
+          this.toggleFavoriteArtist(id);
+          this.$q.notify({
+            type: "positive",
+            message: "Agregado a Favoritos",
+          });
+        });
+        this.addFavourite.artist_id = "";
+      } catch (err) {
+        if (err.response && err.response.data && err.response.data.message) {
+          $q.notify({
+            type: "negative",
+            message: err.response.data.message,
+          });
+        }
+      }
+    },
     async gettArtistBySlug() {
       try {
         await this.getArtistBySlug(this.slug).then(async () => {
@@ -368,6 +403,39 @@ export default {
         this.$q.notify({ type: 'positive', message: 'Link copiado al portapapeles' });
       });
     },
+    isFavoriteArtist(id) {
+      return this.favoriteArtistIds.includes(id);
+    },
+    toggleFavoriteArtist(id) {
+      if (this.favoriteArtistIds.includes(id)) {
+        this.favoriteArtistIds = this.favoriteArtistIds.filter((itemId) => itemId !== id);
+        return;
+      }
+      this.favoriteArtistIds.push(id);
+    },
+    syncFavoriteArtistIds() {
+      if (!Array.isArray(this.stateFavouriteArtists)) {
+        this.favoriteArtistIds = [];
+        return;
+      }
+
+      this.favoriteArtistIds = this.stateFavouriteArtists
+        .map((item) => (item && item.artist ? item.artist.id : null))
+        .filter((id) => id !== null && id !== undefined);
+    },
+    async loadFavouriteArtists() {
+      try {
+        await this.getFavouriteArtists();
+        this.syncFavoriteArtistIds();
+      } catch (err) {
+        if (err.response && err.response.data && err.response.data.message) {
+          $q.notify({
+            type: "negative",
+            message: err.response.data.message,
+          });
+        }
+      }
+    },
     printDateStart: function () {
       return this.formatCartDate(new Date());
     },
@@ -401,8 +469,10 @@ export default {
     this.slug = this.$route.params.slugA;
     this.slugMG = this.$route.params.slugMG;
     this.gettArtistBySlug();
+    this.loadFavouriteArtists();
   },
   computed: {
+    ...mapGetters("favouriteArtists", ["stateFavouriteArtists"]),
     ...mapGetters("auth", ["getMe"]),
     ...mapState({
       artist: (state) => state.clientMusicalGenders.artistGender,


### PR DESCRIPTION
This pull request adds a "favorite artist" feature to the `show.vue` page, allowing users to mark artists as favorites and visually indicates favorite status on the UI. The main changes include managing favorite artist state, updating the favorite button's appearance and behavior, and integrating with the backend to persist favorites.

**Favorite artist feature implementation:**

* The favorite button for each artist now visually reflects whether the artist is a favorite and allows users to add artists to their favorites by clicking it (`src/pages/Client/MusicalGenders/show.vue`).
* Added local state and methods to manage favorite artist IDs, including `favoriteArtistIds`, `addFavouriteArtist`, `isFavoriteArtist`, `toggleFavoriteArtist`, `syncFavoriteArtistIds`, and `loadFavouriteArtists` (`src/pages/Client/MusicalGenders/show.vue`). [[1]](diffhunk://#diff-807b32aa2eba1b58daf7c4ee89bac6ee8d5e4d68c41b93e327e6b8de2486ee0bR274-R277) [[2]](diffhunk://#diff-807b32aa2eba1b58daf7c4ee89bac6ee8d5e4d68c41b93e327e6b8de2486ee0bR307-R331) [[3]](diffhunk://#diff-807b32aa2eba1b58daf7c4ee89bac6ee8d5e4d68c41b93e327e6b8de2486ee0bR406-R438)
* Integrated Vuex actions and getters for fetching and updating favorite artists from the backend (`createFavouriteArtist`, `getFavouriteArtists`, and `stateFavouriteArtists`) (`src/pages/Client/MusicalGenders/show.vue`). [[1]](diffhunk://#diff-807b32aa2eba1b58daf7c4ee89bac6ee8d5e4d68c41b93e327e6b8de2486ee0bR307-R331) [[2]](diffhunk://#diff-807b32aa2eba1b58daf7c4ee89bac6ee8d5e4d68c41b93e327e6b8de2486ee0bR472-R475)

**Lifecycle and state synchronization:**

* On component creation, the list of favorite artists is loaded and kept in sync with the backend (`src/pages/Client/MusicalGenders/show.vue`).

These changes collectively enable users to favorite artists, see their favorite status, and persist this preference across sessions.…st favorite.