### PR TITLE
Add dynamic social media links and icons for artist profiles

### DIFF
--- a/src/pages/Client/MusicalGenders/show.vue
+++ b/src/pages/Client/MusicalGenders/show.vue
@@ -62,9 +62,15 @@
             <div class="row">
               <div class="col-6">
                 <div class="q-mt-sm q-gutter-sm">
-                  <q-btn round color="gray" icon="facebook" size="10px" />
-                  <q-btn round color="gray" icon="facebook" size="10px" />
-                  <q-btn round color="gray" icon="facebook" size="10px" />
+                  <a
+                    v-for="(red, index) in artist.social_media"
+                    :key="index"
+                    :href="red.url"
+                    target="_blank"
+                    class="q-mr-sm"
+                  >
+                    <q-btn round color="primary" :icon="socialIcon(red.nombre)" size="10px" />
+                  </a>
                 </div>
               </div>
               <div class="col-6">
@@ -300,6 +306,16 @@ export default {
           message: "Error al guardar la calificación"
         });
       }
+    },
+    socialIcon(nombre) {
+      const icons = {
+        'Facebook': 'facebook',
+        'Instagram': 'instagram',
+        'X (Twitter)': 'close',
+        'YouTube': 'smart_display',
+        'TikTok': 'music_note',
+      };
+      return icons[nombre] || 'link';
     },
     ...mapActions("clientMusicalGenders", ["getArtistBySlug"]),
     ...mapActions("shoppingCard", ["updateItemShoppingCart"]),


### PR DESCRIPTION
## Summary
This PR improves the artist detail page by replacing static social media buttons with dynamic social media links based on each artist's registered platforms.

## Changes

### Social Media Rendering
- Replaced hardcoded social media buttons with dynamic rendering using `v-for`.
- Added support for opening artist social media profiles in a new tab.

### Dynamic Icons
Implemented a `socialIcon()` helper method to map social platform names to Quasar icons:

- Facebook
- Instagram
- X (Twitter)
- YouTube
- TikTok

### UI Improvements
- Social buttons are now generated automatically from `artist.social_media`.
- Added fallback icon support using `link` when a platform is not recognized.

## Why
Previously, the page displayed static placeholder social buttons that were not connected to artist data.

These changes make the social media section:
- dynamic
- reusable
- data-driven
- more useful for users

## Impact
- Better artist profile experience
- Easier scalability for additional social platforms
- Cleaner and more maintainable frontend code