### PR TITLE
Add artist statistics dashboard cards

### DIFF
--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -363,7 +363,7 @@
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="favorite" color="red" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.favoritos }}</div>
+            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.favorites }}</div>
             <div class="text-subtitle2 text-grey">Personas te tienen como favorito</div>
           </q-card-section>
         </q-card>
@@ -372,7 +372,7 @@
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="star" color="yellow" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.calificacion }}</div>
+            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.rating }}</div>
             <div class="text-subtitle2 text-grey">Calificación promedio ({{ stats.totalReviews }} reseñas)</div>
           </q-card-section>
         </q-card>
@@ -381,10 +381,10 @@
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="event" color="primary" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.cotizaciones }}</div>
+            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.quotations }}</div>
             <div class="text-subtitle2 text-grey">
               Eventos pendientes
-              <span v-if="stats.proximoEvento"><br/>Próximo: {{ stats.proximoEvento }}</span>
+              <span v-if="stats.nextEvent"><br/>Próximo: {{ stats.nextEvent }}</span>
             </div>
           </q-card-section>
         </q-card>
@@ -393,8 +393,8 @@
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="payments" color="green" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">${{ Number(stats.totalVentas).toLocaleString('es-MX') }}</div>
-            <div class="text-subtitle2 text-grey">Generados en {{ stats.totalContrataciones }} contrataciones</div>
+            <div class="text-h4 text-weight-bold q-mt-sm">${{ Number(stats.totalSales).toLocaleString('es-MX') }}</div>
+            <div class="text-subtitle2 text-grey">Generados en {{ stats.totalHires }} contrataciones</div>
           </q-card-section>
         </q-card>
       </div>
@@ -816,13 +816,13 @@ export default {
       linkWhatsApp: "",
       linkCorreo: "",
       stats: {
-        favoritos: 0,
-        calificacion: 0,
+        favorites: 0,
+        rating: 0,
         totalReviews: 0,
-        cotizaciones: 0,
-        proximoEvento: null,
-        totalVentas: 0,
-        totalContrataciones: 0,
+        quotations: 0,
+        nextEvent: null,
+        totalSales: 0,
+        totalHires: 0,
       },
       socialMediaOptions: [
         "Instagram",
@@ -1089,13 +1089,13 @@ export default {
           this.$api.get('/api/artist/quotations/count'),
           this.$api.get('/api/artist/sales/stats'),
         ]);
-        this.stats.favoritos = favRes.data.count;
-        this.stats.calificacion = ratingRes.data.average;
+        this.stats.favorites = favRes.data.count;
+        this.stats.rating = ratingRes.data.average;
         this.stats.totalReviews = ratingRes.data.total;
-        this.stats.cotizaciones = quotRes.data.count;
-        this.stats.proximoEvento = quotRes.data.next_event;
-        this.stats.totalVentas = salesRes.data.total;
-        this.stats.totalContrataciones = salesRes.data.count;
+        this.stats.quotations = quotRes.data.count;
+        this.stats.nextEvent = quotRes.data.next_event;
+        this.stats.totalSales = salesRes.data.total;
+        this.stats.totalHires = salesRes.data.count;
       } catch (e) {
         console.error('Error cargando stats', e);
       }

--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -808,7 +808,6 @@ export default {
         rating: 0,
         totalReviews: 0,
         quotations: 0,
-        nextEvent: null,
         totalSales: 0,
         totalHires: 0,
       },

--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -358,6 +358,48 @@
 
     <notice-gallery></notice-gallery>
 
+    <div class="row q-pa-lg q-col-gutter-md justify-center">
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card class="text-center shadow-4">
+          <q-card-section>
+            <q-icon name="favorite" color="red" size="40px" />
+            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.favoritos }}</div>
+            <div class="text-subtitle2 text-grey">Personas te tienen como favorito</div>
+          </q-card-section>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card class="text-center shadow-4">
+          <q-card-section>
+            <q-icon name="star" color="yellow" size="40px" />
+            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.calificacion }}</div>
+            <div class="text-subtitle2 text-grey">Calificación promedio ({{ stats.totalReviews }} reseñas)</div>
+          </q-card-section>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card class="text-center shadow-4">
+          <q-card-section>
+            <q-icon name="event" color="primary" size="40px" />
+            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.cotizaciones }}</div>
+            <div class="text-subtitle2 text-grey">
+              Eventos pendientes
+              <span v-if="stats.proximoEvento"><br/>Próximo: {{ stats.proximoEvento }}</span>
+            </div>
+          </q-card-section>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card class="text-center shadow-4">
+          <q-card-section>
+            <q-icon name="payments" color="green" size="40px" />
+            <div class="text-h4 text-weight-bold q-mt-sm">${{ Number(stats.totalVentas).toLocaleString('es-MX') }}</div>
+            <div class="text-subtitle2 text-grey">Generados en {{ stats.totalContrataciones }} contrataciones</div>
+          </q-card-section>
+        </q-card>
+      </div>
+    </div>
+
     <div class="row tipogra">
       <div
         :class="mode ? 'title-group-white' : 'title-group'"
@@ -773,6 +815,15 @@ export default {
       },
       linkWhatsApp: "",
       linkCorreo: "",
+      stats: {
+        favoritos: 0,
+        calificacion: 0,
+        totalReviews: 0,
+        cotizaciones: 0,
+        proximoEvento: null,
+        totalVentas: 0,
+        totalContrataciones: 0,
+      },
       socialMediaOptions: [
         "Instagram",
         "X (Twitter)",
@@ -1030,6 +1081,25 @@ export default {
       this.showInfo = "false";
       this.onReset();
     },
+    async loadStats() {
+      try {
+        const [favRes, ratingRes, quotRes, salesRes] = await Promise.all([
+          this.$api.get('/api/artist/favourite_artists/count'),
+          this.$api.get('/api/artist/ratings/average'),
+          this.$api.get('/api/artist/quotations/count'),
+          this.$api.get('/api/artist/sales/stats'),
+        ]);
+        this.stats.favoritos = favRes.data.count;
+        this.stats.calificacion = ratingRes.data.average;
+        this.stats.totalReviews = ratingRes.data.total;
+        this.stats.cotizaciones = quotRes.data.count;
+        this.stats.proximoEvento = quotRes.data.next_event;
+        this.stats.totalVentas = salesRes.data.total;
+        this.stats.totalContrataciones = salesRes.data.count;
+      } catch (e) {
+        console.error('Error cargando stats', e);
+      }
+    },
   },
   computed: {
     ...mapState({
@@ -1049,6 +1119,7 @@ export default {
     $q = useQuasar();
     this.gettArtist();
     this.gettMusicalGenders();
+    this.loadStats();
   },
 };
 </script>

--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -359,7 +359,7 @@
     <notice-gallery></notice-gallery>
 
     <div class="row q-pa-lg q-col-gutter-md justify-center">
-      <div class="col-12 col-sm-6 col-md-3">
+      <div class="col-12 col-sm-6 col-md-4">
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="favorite" color="red" size="40px" />
@@ -368,7 +368,7 @@
           </q-card-section>
         </q-card>
       </div>
-      <div class="col-12 col-sm-6 col-md-3">
+      <div class="col-12 col-sm-6 col-md-4">
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="star" color="yellow" size="40px" />
@@ -377,19 +377,7 @@
           </q-card-section>
         </q-card>
       </div>
-      <div class="col-12 col-sm-6 col-md-3">
-        <q-card class="text-center shadow-4">
-          <q-card-section>
-            <q-icon name="event" color="primary" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.quotations }}</div>
-            <div class="text-subtitle2 text-grey">
-              Eventos pendientes
-              <span v-if="stats.nextEvent"><br/>Próximo: {{ stats.nextEvent }}</span>
-            </div>
-          </q-card-section>
-        </q-card>
-      </div>
-      <div class="col-12 col-sm-6 col-md-3">
+      <div class="col-12 col-sm-6 col-md-4">
         <q-card class="text-center shadow-4">
           <q-card-section>
             <q-icon name="payments" color="green" size="40px" />
@@ -1083,21 +1071,18 @@ export default {
     },
     async loadStats() {
       try {
-        const [favRes, ratingRes, quotRes, salesRes] = await Promise.all([
+        const [favRes, ratingRes, salesRes] = await Promise.all([
           this.$api.get('/api/artist/favourite_artists/count'),
           this.$api.get('/api/artist/ratings/average'),
-          this.$api.get('/api/artist/quotations/count'),
           this.$api.get('/api/artist/sales/stats'),
         ]);
         this.stats.favorites = favRes.data.count;
         this.stats.rating = ratingRes.data.average;
         this.stats.totalReviews = ratingRes.data.total;
-        this.stats.quotations = quotRes.data.count;
-        this.stats.nextEvent = quotRes.data.next_event;
         this.stats.totalSales = salesRes.data.total;
         this.stats.totalHires = salesRes.data.count;
       } catch (e) {
-        console.error('Error cargando stats', e);
+        console.error('Error loading stats', e);
       }
     },
   },


### PR DESCRIPTION
## Summary
This PR adds a new statistics section to the artist dashboard page, providing artists with quick insights about their activity and performance.

## Changes

### Artist Statistics Cards
Added a new responsive statistics section with cards displaying:

- Favorite count
- Average rating and total reviews
- Pending events and next upcoming event
- Total sales and completed bookings

### API Integration
Implemented a new `loadStats()` method that fetches data from multiple endpoints using `Promise.all()`:

- `/api/artist/favourite_artists/count`
- `/api/artist/ratings/average`
- `/api/artist/quotations/count`
- `/api/artist/sales/stats`

### UI Improvements
- Added responsive statistic cards using Quasar components.
- Added formatted currency display using `toLocaleString('es-MX')`.
- Added conditional rendering for upcoming events.
- Added icons and visual indicators for each metric.

## Why
Previously, artists had no quick way to visualize important information about their profile activity and performance.