### PR TITLE
feat: restructure main layout navigation and fix card text contrast

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -21,4 +21,7 @@
     .q-card.shadow-4 {
         background: #1e2a45 !important;
     }
+    .my-card .text-primary {
+        color: #ffffff !important;
+    }
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -41,6 +41,7 @@
           <q-route-tab to="/" label="Inicio" />
           <q-route-tab to="/artist-list" label="Artistas" />
           <q-route-tab to="/about" label="Más" />
+          <q-route-tab to="/dashboard/home" label="Panel" v-if="isAuthenticated == true" />
         </q-tabs>
         <!-- Fin de Links para navegar entre paginas -->
 
@@ -55,23 +56,17 @@
               class="q-mr-sm"
               v-if="isAuthenticated == false"
             />
+          </q-tabs>
 
-            <q-route-tab
-              to="/dashboard/home"
-              label="PANEL"
-              v-if="isAuthenticated == true"
-            />
-          </q-tabs>
-          <q-tabs>
-            <q-btn
-              outline
-              to="/login"
-              color="primary"
-              label="Ingresar"
-              v-if="isAuthenticated == false"
-              class="q-mr-md"
-            />
-          </q-tabs>
+          <q-btn
+            outline
+            to="/login"
+            color="primary"
+            label="Ingresar"
+            v-if="isAuthenticated == false"
+            class="q-mr-md"
+          />
+
           <q-toggle
             v-if="$q.screen.gt.xs"
             v-model="isActiveDarkMode"

--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -474,7 +474,7 @@
             class="q-gutter-md q-px-sm q-py-sm"
           >
             <p class="text-center q-mb-lg text-weight-light text-h3">
-              Editar '{{ artist.name }}'
+              Editar Perfil
             </p>
             <p class="text-center q-mb-sm text-weight-bold">
               Disfruta la nueva experiencia de contratación de servicios


### PR DESCRIPTION
# Description
This PR cleans up the primary application navigation layout in `MainLayout.vue`, addresses a text contrast bug in dark mode styling, and simplifies the header text inside the artist editing view.

## Key Changes
- **Layout & Navigation (`MainLayout.vue`):**
    - Moved the "Panel" (`/dashboard/home`) route tab into the main navigation group for authenticated users to improve UI cohesion.
    - Cleaned up duplicated and fragmented `<q-tabs>` wrappers that were causing layout rendering issues.
    - Re-aligned the "Ingresar" button consistency for unauthenticated states.
- **Styling & CSS (`app.scss`):**
    - Fixed a dark mode visibility bug by ensuring `.text-primary` elements inside `.my-card` properly override to `#ffffff` (white text) for clear contrast.
- **Artist Feature (`index.vue`):**
    - Simplified the editing view header text from a dynamic template literal to a static `"Editar Perfil"`.

## How to Test
1. Log in to the application and verify that the **Panel** tab appears seamlessly alongside "Inicio", "Artistas", and "Más".
2. Log out and ensure the "Ingresar" button retains its original alignment and styling parameters.
3. Inspect any element using `.my-card .text-primary` to confirm that the text overrides cleanly to white and is perfectly readable.
4. Navigate to the Artist creation/edition page (`NewArtist/index.vue`) and check that the title renders correctly as "Editar Perfil".

## Checklist
- [x] Verified component structural layout inside Quasar tabs.
- [x] Text color contrast fixes tested under application view constraints.
- [x] Code contains no remaining console layout or styling regressions.