### PR TITLE
Fix/home groups redirections

### DIFF
--- a/src/middlewares/checkPermissions.js
+++ b/src/middlewares/checkPermissions.js
@@ -3,6 +3,7 @@ import { Store } from "../store/index.js";
 
 export default function checkPermissions({ next, to, from, Router }) {
   const requiredPermissions = to.meta.permissions;
+  const allowedRolesForArtistDetail = ["cliente", "artista", "administrador"];
 
   if (localStorage.getItem("token")) {
     Store.dispatch("auth/getMeUser")
@@ -20,6 +21,14 @@ export default function checkPermissions({ next, to, from, Router }) {
   if (!localStorage.getItem("token")) {
     return Router.push({ name: "LoginIn" });
   } else {
+      const userRole = Store.getters["auth/getMe"]?.role?.[0]
+        ? String(Store.getters["auth/getMe"].role[0]).trim().toLowerCase()
+        : "";
+
+      if (to.name === "client.view-group-by-gender-slug" && allowedRolesForArtistDetail.includes(userRole)) {
+        return next();
+      }
+
     if (!from.name) {
       Store.dispatch("auth/getMeUser").then(() => {
         const canEnter = can(requiredPermissions);

--- a/src/middlewares/checkPermissions.js
+++ b/src/middlewares/checkPermissions.js
@@ -3,7 +3,7 @@ import { Store } from "../store/index.js";
 
 export default async function checkPermissions({ next, to, from, Router }) {
   const requiredPermissions = to.meta.permissions;
-  const allowedRolesForArtistDetail = ["cliente", "artista", "administrador"];
+  const allowedRolesForArtistDetail = ["cliente"];
 
   if (localStorage.getItem("token")) {
     try {

--- a/src/middlewares/checkPermissions.js
+++ b/src/middlewares/checkPermissions.js
@@ -1,49 +1,43 @@
 import can from "../helpers/can";
 import { Store } from "../store/index.js";
 
-export default function checkPermissions({ next, to, from, Router }) {
+export default async function checkPermissions({ next, to, from, Router }) {
   const requiredPermissions = to.meta.permissions;
   const allowedRolesForArtistDetail = ["cliente", "artista", "administrador"];
 
   if (localStorage.getItem("token")) {
-    Store.dispatch("auth/getMeUser")
-      .then(() => {})
-      .catch((err) => {
-        if (err) {
-          if (Store.state.auth.me.name == null) {
-            console.log("entro");
-            window.localStorage.removeItem("token");
-          }
-        }
-      });
+    try {
+      await Store.dispatch("auth/getMeUser");
+    } catch (err) {
+      if (Store.state.auth.me.name == null) {
+        window.localStorage.removeItem("token");
+      }
+    }
   }
 
   if (!localStorage.getItem("token")) {
     return Router.push({ name: "LoginIn" });
-  } else {
-      const userRole = Store.getters["auth/getMe"]?.role?.[0]
-        ? String(Store.getters["auth/getMe"].role[0]).trim().toLowerCase()
-        : "";
-
-      if (to.name === "client.view-group-by-gender-slug" && allowedRolesForArtistDetail.includes(userRole)) {
-        return next();
-      }
-
-    if (!from.name) {
-      Store.dispatch("auth/getMeUser").then(() => {
-        const canEnter = can(requiredPermissions);
-        // console.log(canEnter);
-        if (canEnter) {
-          return next();
-        }
-        return Router.push({ name: from.name, params: from.params });
-      });
-    } else {
-      const canEnter = can(requiredPermissions);
-      if (canEnter) {
-        return next();
-      }
-      return Router.push({ name: from.name, params: from.params });
-    }
   }
+
+  const userRole = Store.getters["auth/getMe"]?.role?.[0]
+    ? String(Store.getters["auth/getMe"].role[0]).trim().toLowerCase()
+    : "";
+
+  if (to.name === "client.view-group-by-gender-slug" && allowedRolesForArtistDetail.includes(userRole)) {
+    return next();
+  }
+
+  if (!from.name) {
+    const canEnter = can(requiredPermissions);
+    if (canEnter) {
+      return next();
+    }
+    return Router.push({ name: from.name, params: from.params });
+  }
+
+  const canEnter = can(requiredPermissions);
+  if (canEnter) {
+    return next();
+  }
+  return Router.push({ name: from.name, params: from.params });
 }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -118,7 +118,7 @@
               </div>
             </q-img>
             <q-btn
-              :to="'/client/musical-genders/'+ stateArtist.musical_genders[0].name + '/' + stateArtist.slug"
+              :to="getArtistRoute(stateArtist)"
               color="primary"
               icon="arrow_forward"
               class="absolute"
@@ -221,6 +221,26 @@ export default {
   methods: {
     ...mapActions("lastArtist", ["getLatestArtists"]),
     ...mapActions("UsersSuscribe", ["setEmail"]),
+    getArtistRoute(stateArtist) {
+      const isLoggedIn = Boolean(this.getToken);
+      const role = this.userRole;
+
+      if (!isLoggedIn) {
+        return "/artist-list";
+      }
+
+      if (!["cliente", "artista", "administrador"].includes(role)) {
+        return "/artist-list";
+      }
+
+      const musicalGender = stateArtist?.musical_genders?.[0]?.name;
+
+      if (!musicalGender || !stateArtist?.slug) {
+        return "/artist-list";
+      }
+
+      return `/client/musical-genders/${musicalGender}/${stateArtist.slug}`;
+    },
     async gettLatestArtists() {
       try {
         await this.getLatestArtists().then(() => {
@@ -258,10 +278,16 @@ export default {
     this.gettLatestArtists();
   },
   computed: {
+    ...mapGetters("auth", ["getMe", "getToken"]),
     ...mapGetters("lastArtist", ["stateArtists"]),
     ...mapGetters("UsersSuscribe", ["stateEmails"]),
     mode: function () {
       return this.$q.dark.isActive;
+    },
+    userRole() {
+      return this.getMe?.role?.[0]
+        ? String(this.getMe.role[0]).trim().toLowerCase()
+        : "";
     },
   },
   mounted() {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -233,7 +233,7 @@ export default {
         return "/artist-list";
       }
 
-      const musicalGender = stateArtist?.musical_genders?.[0]?.name;
+      const musicalGender = stateArtist?.musical_genders?.[0]?.slug;
 
       if (!musicalGender || !stateArtist?.slug) {
         return "/artist-list";

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -229,7 +229,7 @@ export default {
         return "/artist-list";
       }
 
-      if (!["cliente", "artista", "administrador"].includes(role)) {
+      if (role !== "cliente") {
         return "/artist-list";
       }
 


### PR DESCRIPTION
This pull request updates the permissions logic and navigation for artist detail pages, ensuring only users with specific roles can access certain routes. It also improves route generation for artist detail buttons by centralizing the logic and adding robust checks for user authentication and role.

**Permissions and Access Control:**

* Updated `checkPermissions` middleware to allow only users with roles `"cliente"`, `"artista"`, or `"administrador"` to access the `client.view-group-by-gender-slug` route, using a case-insensitive and trimmed role check. [[1]](diffhunk://#diff-da2b8574dafabe0af860254696a15b5684187d276e3217b19c2a4352cff8cff0R6) [[2]](diffhunk://#diff-da2b8574dafabe0af860254696a15b5684187d276e3217b19c2a4352cff8cff0R24-R31)

**Route Generation and Navigation:**

* Refactored the artist detail button in `Index.vue` to use a new `getArtistRoute` method, which generates the route based on the user's authentication status, role, and artist data validity. If checks fail, it redirects to `/artist-list`. [[1]](diffhunk://#diff-75f76a7ed2a0f45f79ae96d58b3530c71c8b88cc3612a84ffd784ba8df2e3cbaL121-R121) [[2]](diffhunk://#diff-75f76a7ed2a0f45f79ae96d58b3530c71c8b88cc3612a84ffd784ba8df2e3cbaR224-R243)

**State and Computed Properties:**

* Added `getMe`, `getToken`, and a computed `userRole` property to `Index.vue` for consistent access to user authentication and role information throughout the component.