### PR TITLE
relocate artist metrics widgets and API fetches from profile to private dashboard

### DIFF
--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -358,36 +358,6 @@
 
     <notice-gallery></notice-gallery>
 
-    <div class="row q-pa-lg q-col-gutter-md justify-center">
-      <div class="col-12 col-sm-6 col-md-4">
-        <q-card class="text-center shadow-4">
-          <q-card-section>
-            <q-icon name="favorite" color="red" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.favorites }}</div>
-            <div class="text-subtitle2 text-grey">Personas te tienen como favorito</div>
-          </q-card-section>
-        </q-card>
-      </div>
-      <div class="col-12 col-sm-6 col-md-4">
-        <q-card class="text-center shadow-4">
-          <q-card-section>
-            <q-icon name="star" color="yellow" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.rating }}</div>
-            <div class="text-subtitle2 text-grey">Calificación promedio ({{ stats.totalReviews }} reseñas)</div>
-          </q-card-section>
-        </q-card>
-      </div>
-      <div class="col-12 col-sm-6 col-md-4">
-        <q-card class="text-center shadow-4">
-          <q-card-section>
-            <q-icon name="payments" color="green" size="40px" />
-            <div class="text-h4 text-weight-bold q-mt-sm">${{ Number(stats.totalSales).toLocaleString('es-MX') }}</div>
-            <div class="text-subtitle2 text-grey">Generados en {{ stats.totalHires }} contrataciones</div>
-          </q-card-section>
-        </q-card>
-      </div>
-    </div>
-
     <div class="row tipogra">
       <div
         :class="mode ? 'title-group-white' : 'title-group'"
@@ -803,14 +773,6 @@ export default {
       },
       linkWhatsApp: "",
       linkCorreo: "",
-      stats: {
-        favorites: 0,
-        rating: 0,
-        totalReviews: 0,
-        quotations: 0,
-        totalSales: 0,
-        totalHires: 0,
-      },
       socialMediaOptions: [
         "Instagram",
         "X (Twitter)",
@@ -1068,22 +1030,6 @@ export default {
       this.showInfo = "false";
       this.onReset();
     },
-    async loadStats() {
-      try {
-        const [favRes, ratingRes, salesRes] = await Promise.all([
-          this.$api.get('/api/artist/favourite_artists/count'),
-          this.$api.get('/api/artist/ratings/average'),
-          this.$api.get('/api/artist/sales/stats'),
-        ]);
-        this.stats.favorites = favRes.data.count;
-        this.stats.rating = ratingRes.data.average;
-        this.stats.totalReviews = ratingRes.data.total;
-        this.stats.totalSales = salesRes.data.total;
-        this.stats.totalHires = salesRes.data.count;
-      } catch (e) {
-        console.error('Error loading stats', e);
-      }
-    },
   },
   computed: {
     ...mapState({
@@ -1103,7 +1049,6 @@ export default {
     $q = useQuasar();
     this.gettArtist();
     this.gettMusicalGenders();
-    this.loadStats();
   },
 };
 </script>

--- a/src/pages/dashboard/Dashboard.vue
+++ b/src/pages/dashboard/Dashboard.vue
@@ -23,6 +23,35 @@
   <client-promotion v-if="getMe.role[0] == 'cliente'"></client-promotion>
   <notice-not-info v-if="getMe.role[0] == 'artista'"></notice-not-info>
   <artist-recomendation v-if="getMe.role[0] == 'artista'"></artist-recomendation>
+  <div v-if="getMe.role[0] == 'artista'" class="row q-pa-lg q-col-gutter-md justify-center">
+    <div class="col-12 col-sm-6 col-md-4">
+      <q-card class="text-center shadow-4">
+        <q-card-section>
+          <q-icon name="favorite" color="red" size="40px" />
+          <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.favorites }}</div>
+          <div class="text-subtitle2 text-grey">Personas te tienen como favorito</div>
+        </q-card-section>
+      </q-card>
+    </div>
+    <div class="col-12 col-sm-6 col-md-4">
+      <q-card class="text-center shadow-4">
+        <q-card-section>
+          <q-icon name="star" color="yellow" size="40px" />
+          <div class="text-h4 text-weight-bold q-mt-sm">{{ stats.rating }}</div>
+          <div class="text-subtitle2 text-grey">Calificación promedio ({{ stats.totalReviews }} reseñas)</div>
+        </q-card-section>
+      </q-card>
+    </div>
+    <div class="col-12 col-sm-6 col-md-4">
+      <q-card class="text-center shadow-4">
+        <q-card-section>
+          <q-icon name="payments" color="green" size="40px" />
+          <div class="text-h4 text-weight-bold q-mt-sm">${{ Number(stats.totalSales).toLocaleString('es-MX') }}</div>
+          <div class="text-subtitle2 text-grey">Generados en {{ stats.totalHires }} contrataciones</div>
+        </q-card-section>
+      </q-card>
+    </div>
+  </div>
   <client-card v-if="getMe.role[0] == 'cliente'"></client-card>
   <notice-general v-if="getMe.role[0] == 'administrador'"></notice-general >
 
@@ -118,6 +147,13 @@ export default {
       columns,
       skeleton: true,
       showCard: true,
+      stats: {
+        favorites: 0,
+        rating: 0,
+        totalReviews: 0,
+        totalSales: 0,
+        totalHires: 0,
+      },
     };
   },
   computed: {
@@ -138,6 +174,22 @@ export default {
             message: err.response.data.message,
           });
         }
+      }
+    },
+    async loadStats() {
+      try {
+        const [favRes, ratingRes, salesRes] = await Promise.all([
+          this.$api.get("/api/artist/favourite_artists/count"),
+          this.$api.get("/api/artist/ratings/average"),
+          this.$api.get("/api/artist/sales/stats"),
+        ]);
+        this.stats.favorites = favRes.data.count;
+        this.stats.rating = ratingRes.data.average;
+        this.stats.totalReviews = ratingRes.data.total;
+        this.stats.totalSales = salesRes.data.total;
+        this.stats.totalHires = salesRes.data.count;
+      } catch (e) {
+        console.error("Error loading stats", e);
       }
     },
     search(slug) {
@@ -182,6 +234,9 @@ export default {
   },
   created() {
     this.gettFavouriteArtists();
+    if (this.getMe?.role?.[0] === 'artista') {
+      this.loadStats();
+    }
   },
   mounted() {
     $q = useQuasar();


### PR DESCRIPTION
## 📝 Description
Relocated the artist metrics metric dashboard cards (favorites count, average star ratings, and cumulative revenue tracking) from the public/creation artist profile page directly to the private user Dashboard view. This refactor improves data privacy and consolidates business analytics where they belong.

---

## 🛠️ Changes Made

###  Artist Profile Layout (`src/pages/Artist/NewArtist/index.vue`)
* Removed the raw HTML statistics cards (`favorites`, `rating`, `totalSales`) from public visibility layers.
* Cleared out the `loadStats()` async API method block and its lifecycle assignment inside `created()`.

###  Private Dashboard View (`src/pages/dashboard/Dashboard.vue`)
* Injected the statistics row wrapper wrapped inside a strict role-based template condition: `v-if="getMe.role[0] == 'artista'"`.
* Ported the asynchronous `loadStats()` multi-endpoint concurrent fetch matrix (`Promise.all`).
* Bound an isolated verification layer within the `created()` hook sequence to safely initialize metrics data collection solely for authenticated `artista` roles, preventing unnecessary API requests for `cliente` or `administrador` profiles.

---

## Visual Checklist (Preview Impact)
- [x] Metrics cards are hidden from public artist view screens.
- [x] Dashboard view shows the correct analytics grid when logged in as an Artist.
- [x] Non-artist roles (Clients, Admins) do not trigger backend analytical endpoints on their dashboard views.

---

##  Type of Change
- [x]  New feature / UX Enhancement (metric widgets migration)
- [x] Refactor (component payload cleanup and logic relocation)