### PR TITLE
enhance delete confirmation messaging and force modal form resets

### DIFF
--- a/src/pages/Admin/MusicalGenders/index.vue
+++ b/src/pages/Admin/MusicalGenders/index.vue
@@ -466,7 +466,7 @@ export default {
         this.$q
           .dialog({
             title: "Mensaje de confirmación",
-            message: `¿Estás seguro de eliminar el registro de ${name}?`,
+            message: `¿Estás seguro de eliminar el género musical ${name}?`,
             cancel: "Cancelar",
             ok: "Confirmar",
             persistent: true,

--- a/src/pages/Admin/Roles/index.vue
+++ b/src/pages/Admin/Roles/index.vue
@@ -82,7 +82,7 @@
   <!-- Inicio de Formulario nuevo rol -->
   <section>
     <div class="q-pa-md q-gutter-sm">
-      <q-dialog v-model="formCreate" persistent>
+      <q-dialog v-model="formCreate" persistent @hide="onReset">
         <q-card style="min-width: 350px">
           <q-card-section>
             <div class="text-h6">Crear rol</div>
@@ -335,7 +335,7 @@ export default {
         this.$q
           .dialog({
             title: "Mensaje de confirmación",
-            message: `¿Estás seguro de eliminar el registro de ${name}?`,
+            message: `¿Estás seguro de eliminar el rol ${name}?`,
             cancel: "Cancelar",
             ok: "Confirmar",
             persistent: true,

--- a/src/pages/Admin/Users/index.vue
+++ b/src/pages/Admin/Users/index.vue
@@ -20,7 +20,7 @@
             label="Nuevo"
             icon-right="fas fa-plus"
             size="sm"
-            @click="formCreate = true"
+            @click="clearForm(); formCreate = true"
             v-if="$can('create-users')"
           />
         </b>
@@ -83,7 +83,7 @@
   <!-- Inicio de Formulario nuevo usuario -->
   <section>
     <div class="q-pa-md q-gutter-sm">
-      <q-dialog v-model="formCreate" persistent>
+      <q-dialog v-model="formCreate" persistent @hide="clearForm">
         <q-card style="min-width: 350px">
           <q-card-section>
             <div class="text-h6">
@@ -370,7 +370,7 @@ export default {
       this.$q
         .dialog({
           title: "Mensaje de confirmación",
-          message: `¿Estás seguro de eliminar el registro de ${props.row.name}?`,
+          message: `¿Estás seguro de eliminar al usuario ${props.row.name}?`,
           cancel: "Cancelar",
           ok: "Confirmar",
           persistent: true,


### PR DESCRIPTION
## 📝 Description
This PR improves the overall User Experience (UX) and fixes data persistence bugs inside the Admin Management views. It provides explicit messaging within delete confirmation dialogs and guarantees form state resets when dynamic modals are closed or re-opened.

---

## 🛠️ Changes Made

### 📋 Admin Management Modules (`src/pages/Admin/`)

#### **`MusicalGenders/index.vue`**
* Updated the delete confirmation dialogue phrasing from a generic registration placeholder string to explicitly state `"el género musical [name]"`.

#### **`Roles/index.vue`**
* Attached an `@hide="onReset"` event hook onto the role creation `q-dialog` container to seamlessly scrub stale inputs upon closing.
* Refactored delete text to state explicitly `"el rol [name]"`.

#### **`Users/index.vue`**
* Extended the configuration of the "New User" trigger button action sequence to clear existing forms by executing `clearForm()` before flipping the visibility visibility flags (`formCreate = true`).
* Attached an `@hide="clearForm"` event hook configuration to secure input cleanups when users exit out of dialog cards.
* Tailored localized deletion confirmations to clearly prompt `"al usuario [name]"`.

---

##  Visual Checklist (Preview Impact)
- [x] Modal creation fields are fully blank and tracking cleanly when closed and reopened.
- [x] Deletion popups explicitly display human-readable context classifications depending on the panel component module.

---

## Type of Change
- [x]  Bug fix (non-breaking change which fixes stale modal cache variables)
- [x]  UX / UI Refactor (text copy improvements and field reset automation hooks)