### PR TITLE
fix: prevent preview and instantly reject invalid image formats on up…

### DIFF
--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -19,11 +19,13 @@
 
             <q-card-section class="q-pt-none">
               <q-uploader
+                ref="uploaderCreate"
                 label="Selecciona las imágenes (Máx. 5)"
                 max-files="5"
                 multiple
                 accept=".jpg, image/*"
                 :factory="uploadSubImages"
+                @added="(files) => validateAddedFiles(files, 'uploaderCreate')"
                 @rejected="onRejected"
                 color="accent"
                 max-file-size="1000000"
@@ -104,8 +106,8 @@
               <p class="">
                 Todas las imágenes anteriores serán eliminadas y sustituidas por
                 las que selecciones.
+                ¿Estás seguro de eliminar las imágenes anteriores?
               </p>
-              ¿Estás seguro de eliminar las imágenes anteriores?
               <q-btn
                 :disable="btnDelete"
                 label="Confirmar"
@@ -116,12 +118,14 @@
 
             <q-card-section class="q-pt-none">
               <q-uploader
+                ref="uploaderEdit"
                 :disable="formGalleryShow"
                 label="Selecciona las imagenes (Max 5)"
                 max-files="5"
                 multiple
                 accept=".jpg, image/*"
                 :factory="updateSubImages"
+                @added="(files) => validateAddedFiles(files, 'uploaderEdit')"
                 @rejected="onRejected"
                 color="accent"
                 max-file-size="1000000"
@@ -188,53 +192,91 @@ export default {
         }
       }
     },
-
     async uploadSubImages(files) {
       try {
         this.sub_files_paths = files[0];
         let InstFormData = new FormData();
         InstFormData.append("sub_files_paths", this.sub_files_paths);
-        await this.createGalleryArtist(InstFormData).then(() => {
-          this.showGallery = true;
-          $q.notify({
-            type: "positive",
-            message: "Imagen subida correctamente",
-          });
+        
+        await this.createGalleryArtist(InstFormData);
+        
+        this.showGallery = true;
+        this.$q.notify({
+          type: "positive",
+          message: "Imagen subida correctamente",
         });
         this.sub_files_paths = null;
       } catch (err) {
-        if (err.response.data.message) {
-          $q.notify({
+          if (this.$refs.uploaderCreate) {
+            this.$refs.uploaderCreate.reset(); 
+          }
+          this.$q.notify({ 
             type: "negative",
-            message: err.response.data.message,
+            message: "Revisa que el formato de la imagen sea el esperado (jpg, png, jpeg, jpe) y que el tamaño no supere lo permitido.",
           });
         }
-      }
     },
-    async updateSubImages(files) {
-      try {
-        this.sub_files_paths = files[0];
-        let InstFormData = new FormData();
-        InstFormData.append("sub_files_paths", files[0]);
-        await this.upDateGalleryArtist(InstFormData).then(() => {
-          this.showGallery = true;
-          $q.notify({
-            type: "positive",
-            message: "Imagen subida correctamente",
-          });
-          this.btnDelete = false;
-          this.formGalleryShow = true;
-          this.formGalleryEdit = false;
+  async updateSubImages(files) {
+    try {
+      this.sub_files_paths = files[0];
+      let InstFormData = new FormData();
+      InstFormData.append("sub_files_paths", files[0]);
+      
+      await this.upDateGalleryArtist(InstFormData);
+      
+      this.showGallery = true;
+      this.$q.notify({ 
+        type: "positive",
+        message: "Imagen subida correctamente",
+      });
+      this.btnDelete = false;
+      this.formGalleryShow = true;
+      this.formGalleryEdit = false;
+    } catch (err) {
+      if (this.$refs.uploaderEdit) {
+        this.$refs.uploaderEdit.reset();
+      }
+
+      this.$q.notify({
+        type: "negative",
+        message: "Revisa que el formato de la imagen sea el esperado (jpg, png, jpeg, jpe) y que el tamaño no supere lo permitido.",
+      });
+    }
+  },
+
+  async gettGalleryArtist() {
+    try {
+      await this.getGalleryArtist();
+      if (this.galleryArtist && this.galleryArtist[0] != null) {
+        this.showGallery = true;
+      } else {
+        this.showGallery = false;
+      }
+    } catch (err) {
+      this.$q.notify({
+        type: "negative",
+        message: err.message || "Error al obtener la galería",
+      });
+    }
+  },
+  validateAddedFiles(files, uploaderRef) {
+    const uploader = this.$refs[uploaderRef];
+    if (!uploader) return;
+
+    const validExtensions = ['jpg', 'jpeg', 'png', 'jpe'];
+
+    files.forEach((file) => {
+      const fileExtension = file.name.split('.').pop().toLowerCase();
+
+      if (!validExtensions.includes(fileExtension)) {
+        uploader.removeFile(file);
+        this.$q.notify({
+          type: "negative",
+          message: `El archivo "${file.name}" no tiene un formato válido (Solo jpg, jpeg, png).`,
         });
-      } catch (err) {
-        if (err.response.data.message) {
-          $q.notify({
-            type: "negative",
-            message: err.response.data.message,
-          });
-        }
       }
-    },
+    });
+  },
     formDelete() {
       this.$q
         .dialog({

--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -176,22 +176,7 @@ export default {
     ...mapActions("galleryArtist", ["createGalleryArtist"]),
     ...mapActions("galleryArtist", ["upDateGalleryArtist"]),
     ...mapActions("galleryArtist", ["deleteGalleryArtist"]),
-    async gettGalleryArtist() {
-      try {
-        await this.getGalleryArtist();
-        //console.log(this.galleryArtist);
-        if (this.galleryArtist[0] != null) {
-          this.showGallery = true;
-        } else this.showGallery = false;
-      } catch (err) {
-        if (err.response.data.message) {
-          $q.notify({
-            type: "negative",
-            message: err.message,
-          });
-        }
-      }
-    },
+    
     async uploadSubImages(files) {
       try {
         this.sub_files_paths = files[0];

--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -23,7 +23,7 @@
                 label="Selecciona las imágenes (Máx. 5)"
                 max-files="5"
                 multiple
-                accept=".jpg, image/*"
+                accept=".jpg, .jpeg, .png, .jpe"
                 :factory="uploadSubImages"
                 @added="(files) => validateAddedFiles(files, 'uploaderCreate')"
                 @rejected="onRejected"
@@ -123,7 +123,7 @@
                 label="Selecciona las imagenes (Max 5)"
                 max-files="5"
                 multiple
-                accept=".jpg, image/*"
+                accept=".jpg, .jpeg, .png, .jpe"
                 :factory="updateSubImages"
                 @added="(files) => validateAddedFiles(files, 'uploaderEdit')"
                 @rejected="onRejected"

--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -232,11 +232,7 @@ export default {
   async gettGalleryArtist() {
     try {
       await this.getGalleryArtist();
-      if (this.galleryArtist && this.galleryArtist[0] != null) {
-        this.showGallery = true;
-      } else {
-        this.showGallery = false;
-      }
+      this.showGallery = (this.galleryArtist && this.galleryArtist[0] != null);
     } catch (err) {
       this.$q.notify({
         type: "negative",

--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -257,7 +257,7 @@ export default {
         uploader.removeFile(file);
         this.$q.notify({
           type: "negative",
-          message: `El archivo "${file.name}" no tiene un formato válido (Solo jpg, jpeg, png).`,
+          message: `El archivo "${file.name}" no tiene un formato válido (Solo jpg, jpeg, png, jpe).`,
         });
       }
     });


### PR DESCRIPTION
## Overview
This PR improves the UX of the image gallery component (`NoticeGallery.vue`) by preventing invalid files from generating a preview in the `<q-uploader>` component. 

Previously, files with invalid extensions would still display a preview until the upload button was pressed. Now, validations are triggered immediately when files are selected.

## Changes
- Added `@added` event interceptor to both `uploaderCreate` and `uploaderEdit` components.
- Implemented `validateAddedFiles` method to check file extensions (`.jpg`, `.jpeg`, `.png`, `.jpe`) before the preview is rendered.
- Used `uploader.removeFile(file)` to immediately drop invalid files from the queue and trigger a Quasar negative notification.
- Fixed an issue where `$q.notify` calls were missing the `this.` context within async methods.

## How to Test
1. Open the gallery dialog (Create or Edit).
2. Drag or select an invalid file format (e.g., a `.pdf` or `.txt` file).
3. **Expected result:** The file should NOT show up in the preview list, and a red error notification should appear immediately.
4. Drag a valid image (`.jpg`, `.png`).
5. **Expected result:** The preview should display normally and allow uploading.