### PR TITLE
translate newsletter UI and routes to Spanish

### DIFF
--- a/src/layouts/Dashboard.vue
+++ b/src/layouts/Dashboard.vue
@@ -127,7 +127,7 @@
               <q-icon name="fas fa-newspaper" />
             </q-item-section>
 
-            <q-item-section> Newsletter </q-item-section>
+            <q-item-section> Envío de Correos </q-item-section>
           </q-item>
 
           <q-item

--- a/src/pages/Admin/EmailSubscribedUsers/index.vue
+++ b/src/pages/Admin/EmailSubscribedUsers/index.vue
@@ -1,7 +1,7 @@
 <template>
     <q-card style="margin-top:-50px; width: 100%; padding: 10px;">
         <q-card-section>
-        <h3 class="q-mb-md" style="margin-bottom: 35px;">Newsletter</h3>
+        <h3 class="q-mb-md" style="margin-bottom: 35px;">Envío de Correos</h3>
             <q-select
             v-model="selectedRoles"
             :options="rolesOptions"
@@ -37,7 +37,7 @@
             toolbar-text-color="white"
             required
             :definitions="{
-                bold: {label: 'Bold', icon: null, tip: 'My bold tooltip'}
+                bold: {label: 'Negrita', icon: null, tip: 'Poner texto en negrita'}
             }"
             ></q-editor>
 

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -169,7 +169,7 @@ const routes = [
         path: "/admin/newsletter/index",
         component: import("pages/Admin/EmailSubscribedUsers/index.vue"),
         meta: {
-          title: "Buzón",
+          title: "Envío de Correos",
           requireLogin: true,
           permissions: ["view-users"],
         },


### PR DESCRIPTION
## Summary of Changes

### Admin Newsletter Module Renaming
- Updated the Newsletter section label in the dashboard sidebar to **"Envío de Correos"** for clearer functionality identification.
- Renamed the page header from **"Newsletter"** to **"Envío de Correos"** in the email management view.
- Updated the route metadata title from **"Buzón"** to **"Envío de Correos"** to maintain consistent naming across the application.

### Editor Localization Improvements
- Translated the editor's **Bold** formatting option to Spanish:
  - Label changed from **"Bold"** to **"Negrita"**.
  - Tooltip changed from **"My bold tooltip"** to **"Poner texto en negrita"**.