### PR TITLE
fix: resolve pagination layout issue by explicitly setting rowsPerPag…

### DIFF
--- a/src/pages/Client/FavouriteArtists/index.vue
+++ b/src/pages/Client/FavouriteArtists/index.vue
@@ -6,6 +6,7 @@
         card-class="bg-primary text-white"
         :rows="stateFavouriteArtists"
         :columns="columns"
+        :pagination="pagination"
         row-key="name"
         no-data-label="Sin registros"
         no-results-label="Ningún registro coincidente"
@@ -117,6 +118,9 @@ export default {
     return {
       columns,
       skeleton: true,
+      pagination: {
+        rowsPerPage: 6
+      }
     };
   },
   methods: {


### PR DESCRIPTION
## Description
This PR fixes a pagination and grid layout bug in the Favorite Artists view (`FavouriteArtists/index.vue`):

* **The Issue:** When a user added a 6th favorite artist, the card was automatically pushed to the next pagination page, leaving an awkward blank space in the 3-column responsive grid layout (`col-md-4`). This occurred because Quasar's `<q-table>` defaults to a maximum of 5 rows per page if unconfigured.
* **The Solution:** Added an explicit `:pagination` data configuration setting `rowsPerPage: 6`. This ensures that up to two full rows of cards render symmetrically on a single page before initializing pagination, preserving the visual balance of the UI.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Style / UI improvement

## How Has This Been Tested?
- Added multiple favorite artists (up to 6 and beyond) to confirm they fill the responsive grid rows completely without creating unexpected blank spaces or premature pagination splits.