### PR TITLE
Feature: Add horizontal image validation for artist gallery uploads

### DIFF
--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -255,7 +255,26 @@ export default {
           type: "negative",
           message: `El archivo "${file.name}" no tiene un formato válido (Solo jpg, jpeg, png, jpe).`,
         });
+        return;
       }
+
+      const img = new Image();
+      const url = URL.createObjectURL(file);
+      img.onload = () => {
+        URL.revokeObjectURL(url);
+        if (img.width <= img.height) {
+          uploader.removeFile(file);
+          this.$q.notify({
+            type: "negative",
+            message: `"${file.name}" debe ser horizontal (ancho mayor que alto).`,
+          });
+        }
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        uploader.removeFile(file);
+      };
+      img.src = url;
     });
   },
     formDelete() {


### PR DESCRIPTION
**Summary**

This PR introduces validation to ensure that only horizontal images can be uploaded to the artist gallery.

The validation was implemented on both the backend and frontend to provide immediate user feedback and enforce image orientation requirements consistently across the application.

Additionally, the gallery upload notice was updated to clearly communicate the accepted image format to artists before uploading.

**Changes Implemented**

🔹 Backend Validation

- Added image orientation validation for gallery uploads.
- Restricted uploads to horizontal images only.
- Improved validation consistency during image processing.

🔹 Frontend Validation & UX

- Updated gallery upload guidance and validation messaging.
- Improved user feedback when attempting to upload unsupported images.
- Clarified gallery image requirements for artists.

**📁 Files Modified**

Components

- src/components/Artist/NoticeGallery.vue
