### PR TITLE
fix(musical-genders): implement client-side duplicate validation for …

### DIFF
--- a/src/pages/Admin/MusicalGenders/index.vue
+++ b/src/pages/Admin/MusicalGenders/index.vue
@@ -407,16 +407,30 @@ export default {
       }
     },
     async createNewMusicalGender() {
-      try {
-        await this.createMusicalGender(this.form);
-        this.formCreate = false;
-        this.onReset();
+      const newName = this.form.name ? this.form.name.trim().toLowerCase() : "";
+
+      const duplicateExists = this.rows.some(
+        (row) => row.name.trim().toLowerCase() === newName
+      );
+
+      if (duplicateExists) {
         this.$q.notify({
-          type: "positive",
-          message: `Género musical creado correctamente`,
+          type: "negative",
+          message: `El género musical "${this.form.name}" ya existe en el sistema.`,
+          position: "bottom"
         });
+        return;
+      }
+      try {
+          await this.createMusicalGender(this.form);
+          this.formCreate = false;
+          this.onReset();
+          this.$q.notify({
+            type: "positive",
+            message: `Género musical creado correctamente`,
+          });
       } catch (err) {
-        if (err.response.data.message) {
+        if (err.response && err.response.data && err.response.data.message) {
           $q.notify({
             type: "negative",
             message: err.response.data.message,


### PR DESCRIPTION
## Description
Added a preventive client-side validation in the musical genders creation form to check for existing records before sending a request to the server, improving the user experience (UX) and reducing unnecessary network overhead.

## Changes Made
- Modified `createNewMusicalGender` method in `index.vue` to check for duplicates using `.some()`.
- Normalized strings using `.trim().toLowerCase()` to ensure strict matching regardless of spacing or letter case.
- Cleaned up a duplicated line within the `catch` block.
- Refactored the error notifications to consistently handle server response failures.

## How to Test
1. Go to the Musical Genders administration page.
2. Click "Nuevo" and attempt to type a genre that is already displayed in the table (e.g., trying "Rock" or "  rock  ").
3. Verify that a bottom notification appears immediately saying *"El género musical... ya existe..."* and no network request is made.