### PR TITLE
implement responsive grid mode for data tables in users, roles, and m…

### DIFF
--- a/src/pages/Admin/MusicalGenders/index.vue
+++ b/src/pages/Admin/MusicalGenders/index.vue
@@ -10,6 +10,7 @@
       no-data-label="Sin registros"
       no-results-label="No hay registros que coincidan"
       rows-per-page-label="Géneros por página"
+      :grid="$q.screen.lt.md"
     >
       <template v-slot:top>
         <b class="text-h5">
@@ -71,6 +72,44 @@
             ></q-btn>
           </q-td>
         </q-tr>
+      </template>
+
+      <template v-slot:item="props">
+        <div class="q-pa-xs col-xs-12 col-sm-6 col-md-4">
+          <q-card class="q-pa-sm">
+            <q-list dense>
+              <q-item v-for="col in props.cols" :key="col.name">
+                <q-item-section>
+                  <q-item-label caption>{{ col.label }}</q-item-label>
+                  <q-item-label v-if="col.name === 'options'">
+                    <q-btn
+                      dense
+                      round
+                      flat
+                      color="primary"
+                      @click="showMusicalGender(props)"
+                      icon="edit"
+                      v-if="auth.role[0] == 'administrador'"
+                    ></q-btn>
+                    <q-btn
+                      dense
+                      round
+                      flat
+                      color="red"
+                      @click="removeMusicalGender(props)"
+                      icon="delete"
+                      v-if="auth.role[0] == 'administrador'"
+                    ></q-btn>
+                  </q-item-label>
+                  <q-item-label v-else-if="col.name === 'created_at'">
+                    {{ formatDate(props.row.created_at) }}
+                  </q-item-label>
+                  <q-item-label v-else>{{ col.value }}</q-item-label>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-card>
+        </div>
       </template>
 
       <template v-slot:loading>

--- a/src/pages/Admin/Roles/index.vue
+++ b/src/pages/Admin/Roles/index.vue
@@ -10,6 +10,7 @@
       no-data-label="Sin registros"
       no-results-label="No se encontraron registros"
       rows-per-page-label="Roles por página"
+      :grid="$q.screen.lt.md"
     >
       <template v-slot:top>
         <b class="text-h5">
@@ -68,6 +69,28 @@
             ></q-btn>
           </q-td>
         </q-tr>
+      </template>
+
+      <template v-slot:item="props">
+        <div class="q-pa-xs col-xs-12 col-sm-6 col-md-4">
+          <q-card class="q-pa-sm">
+            <q-list dense>
+              <q-item v-for="col in props.cols" :key="col.name">
+                <q-item-section>
+                  <q-item-label caption>{{ col.label }}</q-item-label>
+                  <q-item-label v-if="col.name === 'options'">
+                    <q-btn dense round flat color="primary" @click="showRole(props)" icon="edit"></q-btn>
+                    <q-btn dense round flat color="red" @click="removeRole(props)" icon="delete"></q-btn>
+                  </q-item-label>
+                  <q-item-label v-else-if="col.name === 'created_at'">
+                    {{ formatDate(props.row.created_at) }}
+                  </q-item-label>
+                  <q-item-label v-else>{{ col.value }}</q-item-label>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-card>
+        </div>
       </template>
 
       <template v-slot:loading>

--- a/src/pages/Admin/Users/index.vue
+++ b/src/pages/Admin/Users/index.vue
@@ -10,6 +10,7 @@
       no-data-label="Sin registros"
       no-results-label="No hay registros que coincidan."
       rows-per-page-label="Usuarios por página"
+      :grid="$q.screen.lt.md"
     >
       <template v-slot:top>
         <b class="text-h5">
@@ -69,6 +70,28 @@
             ></q-btn>
           </q-td>
         </q-tr>
+      </template>
+
+      <template v-slot:item="props">
+        <div class="q-pa-xs col-xs-12 col-sm-6 col-md-4">
+          <q-card class="q-pa-sm">
+            <q-list dense>
+              <q-item v-for="col in props.cols" :key="col.name">
+                <q-item-section>
+                  <q-item-label caption>{{ col.label }}</q-item-label>
+                  <q-item-label v-if="col.name === 'options'">
+                    <q-btn dense round flat color="primary" @click="showUser(props)" icon="edit"></q-btn>
+                    <q-btn dense round flat color="red" @click="removeUser(props)" icon="delete"></q-btn>
+                  </q-item-label>
+                  <q-item-label v-else-if="col.name === 'created_at'">
+                    {{ formatDate(props.row.created_at) }}
+                  </q-item-label>
+                  <q-item-label v-else>{{ col.value }}</q-item-label>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-card>
+        </div>
       </template>
 
       <template v-slot:loading>


### PR DESCRIPTION
## Summary of Changes
Implemented a responsive grid view for tables on mobile screens across multiple Admin pages.

## Modified Files:

src/pages/Admin/MusicalGenders/index.vue

src/pages/Admin/Roles/index.vue

src/pages/Admin/Users/index.vue

## Key Updates:

Responsive Grid Activation: Added the :grid="$q.screen.lt.md" property to the tables, enabling a grid-style layout for devices with screens smaller than medium (tablets and mobile).

Mobile Card Layout (v-slot:item): Designed a custom template to display each table row as a <q-card> when in grid mode. The data is neatly organized inside a <q-list>.

Action Buttons & Formatting: * Maintained specific conditional logic for the options column inside the mobile cards, displaying the Edit and Delete icon buttons appropriately (including preserving the administrator role check v-if="auth.role[0] == 'administrador'" in the Musical Genders page).

Ensured the created_at column retains its date formatting via the formatDate() function within the new card layout.