### PR TITLE
Adjust dashboard artist navigation permissions and remove searchbar vitrual scroll

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -14,7 +14,6 @@
         option-value="url"
         hide-dropdown-icon
         :loading="loading"
-        @virtual-scroll="onScroll"
     >
         <template v-slot:option="scope">
         <q-item v-bind="scope.itemProps" @click="redirectToRoute(scope.opt.url)">

--- a/src/layouts/Dashboard.vue
+++ b/src/layouts/Dashboard.vue
@@ -133,8 +133,8 @@
           <q-item
             clickable
             v-ripple
-            to="/artist-list?offers=true"
-            v-if="$can('create-card')"
+            to="/artist/index"
+            v-if="$can('view-profile-artist')"
             active-class="text-accent text-weight-bold"
           >
             <q-item-section avatar>


### PR DESCRIPTION
📝 **Description**
This PR cleans up the layout navigation permissions for the artist list and refactors the global search component UI behavior.

🎯 **Why?**
* **Permission Alignment:** The dashboard layout was checking for `create-card` instead of the explicit `view-profile-artist` permission to access the index view.
* **Component Optimization:** The virtual scroll event listener on the search input was causing redundant rendering overhead without functional utility.

⚡ **Impact**
* **Correct Access Control:** Artists with appropriate profile views can now access their target routing dashboard link correctly.
* **Cleaner Search Performance:** Removed dead event attachments on the global search bar dropdown.

🛠️ **Changes Made**
* `src/layouts/Dashboard.vue`: Swapped the routing target to `/artist/index` and updated the gate check to `$can('view-profile-artist')`.
* `src/components/SearchBar/SearchBar.vue`: Cleaned up the `@virtual-scroll` listener from the Quasar select component.

🏷️ **Type of Change**
 🐛 Bug fix (Permission mapping & UI adjustments)