### PR TITLE
fix(offers): update quasar form validation rules to limit max discoun…

### DIFF
--- a/src/pages/Artist/Offers/index.vue
+++ b/src/pages/Artist/Offers/index.vue
@@ -105,12 +105,10 @@
               outlined
               type="number"
               min="1"
-              max="100"
-              :rules="[
+              max="90" :rules="[
                 val => !!val || 'El descuento es requerido',
                 val => val >= 1 || 'El descuento mínimo es 1%',
-                val => val <= 100 || 'El descuento no puede ser mayor al 100%'
-              ]"
+                val => val <= 90 || 'El descuento no puede ser mayor al 90%' ]"
             />
             <div>
               <div class="text-caption text-grey-7 q-mb-xs">Fecha inicio</div>


### PR DESCRIPTION
## Description
This PR updates the "Mis Ofertas" module form validation to restrict the maximum allowable discount percentage to 90%. Previously, the input allowed up to 100%, which could lead to business logic inconsistencies or payment processing errors.

## Changes Made
- **UI Constraint Update:** Modified the `<q-input>` type number component for `discount_percentage` to change the `max` attribute value from `100` to `90`.
- **Form Rule Refactoring:** Updated the reactive inline validation array to block any value higher than 90, throwing the explicit user error: `'El descuento no puede ser mayor al 90%'`.

## How to Test
1. Access the "Mis Ofertas" view and click on "Nueva Oferta" or edit an active offer.
2. Input `100` or higher into the "Descuento (%)" field.
3. Verify that the form immediately flags the field as invalid and blocks the "Guardar" submit action.
4. Input `90` or less and verify the form validates successfully.