### PR TITLE
fix(ui): replace unauthenticated error toast with friendly logout not…

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -370,19 +370,30 @@ export default {
         }
       }
     },
-    async fetchShoppingCartCount() {
-      try {
-        if (this.isAuthenticated) {
-          await this.getCountListShoppingCard();
-        }
-      } catch (err) {
-        const message = err?.response?.data?.message || "No se pudo cargar el carrito.";
-        this.$q.notify({
-          type: "negative",
-          message,
-        });
-      }
-    },
+async fetchShoppingCartCount() {
+  try {
+    if (this.isAuthenticated) {
+      await this.getCountListShoppingCard();
+    }
+  } catch (err) {
+    const message = err?.response?.data?.message || "No se pudo cargar el carrito.";
+    if (message === 'Unauthenticated.' || err?.response?.status === 401) {
+      this.$q.notify({
+        color: "primary",      
+        textColor: "white",    
+        icon: "sentiment_satisfied_alt", 
+        message: '¡Hasta luego!',
+        timeout: 2000,         
+        position: "bottom"        
+      });
+      return; 
+    }
+    this.$q.notify({
+      type: "negative",
+      message,
+    });
+  }
+},
     darkMode(val) {
       this.$q.dark.set(val);
       const user = this.getMe;


### PR DESCRIPTION
## Description
This PR addresses a minor user experience issue where a red "Unauthenticated." error notification would trigger upon logging out. This occurred because the shopping cart count fetch request was still in-flight or triggered asynchronously right as the auth state was being cleared. 

The error handler has been updated to intercept this specific case and replace the negative alert with a friendly, branded departure message.

## Changes Made
- **UX Notification Refactor:** Updated the `catch` block inside `fetchShoppingCartCount()` to detect `Unauthenticated.` messages or `401` HTTP status codes.
- **Visual Styling Update:** Replaced Quasar's negative (`type: "negative"`) red banner with a smooth, branded notification using the application's `primary` color theme, a friendly icon, and a customized greeting message ("¡Hasta luego!").
- **Execution Flow:** Added an early return inside the intercepted block to cleanly stop further error propagation.

## How to Test
1. Log into the application using any valid user account.
2. Click the **Cerrar Sesión** (Logout) button.
3. Verify that the intrusive red error banner no longer appears.
4. Instead, ensure a clean, blue notification pops up at the bottom of the screen displaying "¡Hasta luego!" for 2 seconds before fading out.