### PR TITLE
Feature: Format seeded card numbers with four-digit separators

### DIFF
--- a/src/pages/Client/ShoppingCart/dataClient.vue
+++ b/src/pages/Client/ShoppingCart/dataClient.vue
@@ -1229,7 +1229,7 @@ export default defineComponent({
           console.warn('Device data setup fallido, continuando sin él:', e);
         }
 
-        const card_number = this.selectedCard.number_card.replace(/\s/g, "");
+        const card_number = this.selectedCard.number_card.replace(/[\s-]/g, "");
         const [month, year] = this.selectedCard.expiration_date.split('/');
 
         OpenPay.token.create(
@@ -1308,7 +1308,7 @@ export default defineComponent({
                 try {
                   const cardToSave = {
                     name: this.selectedCard.name,
-                    number_card: (this.selectedCard.number_card || '').replace(/\s/g, ''),
+                    number_card: (this.selectedCard.number_card || '').replace(/[\s-]/g, ''),
                     expiration_date: this.selectedCard.expiration_date,
                   };
                   await this.createCard(cardToSave);


### PR DESCRIPTION
**Summary**

This PR updates the card generation logic used in the seeder to format card numbers with a hyphen (-) every four digits.

The new format improves readability and provides a more realistic representation of card numbers within development and testing environments.

**📁 Files Modified**

Frontend

Checkout

- src/pages/Client/ShoppingCart/dataClient.vue