### PR TITLE
feat(ui): add adaptive bank payout information form for artists

### DIFF
--- a/src/layouts/Dashboard.vue
+++ b/src/layouts/Dashboard.vue
@@ -178,7 +178,17 @@
             </q-item-section>
             <q-item-section>Mis Ofertas</q-item-section>
           </q-item>
-
+          <q-item
+            clickable
+            v-ripple
+            to="/artist/payout-info"
+            v-if="getMe.role[0] == 'artista'"
+            active-class="text-accent text-weight-bold">
+            <q-item-section avatar>
+              <q-icon name="account_balance" />
+            </q-item-section>
+            <q-item-section> Datos de Cobro </q-item-section>
+          </q-item>
           <q-item
             v-show="false"
             clickable

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -137,6 +137,10 @@
               <q-item-section avatar><q-icon name="fas fa-solid fa-cart-arrow-down" /></q-item-section>
               <q-item-section> Mis ventas </q-item-section>
             </q-item>
+            <q-item clickable v-ripple to="/artist/payout-info" v-if="getMe.role[0] == 'artista'" active-class="text-accent text-weight-bold">
+              <q-item-section avatar><q-icon name="account_balance" /></q-item-section>
+              <q-item-section> Datos de Cobro </q-item-section>
+            </q-item>
             <q-item clickable v-ripple to="/artist/artistSales" v-if="getMe.role[0] == 'artista'" active-class="text-accent text-weight-bold">
               <q-item-section avatar><q-icon name="fas fa-solid fa-calendar" /></q-item-section>
               <q-item-section> Mi calendario </q-item-section>

--- a/src/pages/Artist/PayoutInfo/index.vue
+++ b/src/pages/Artist/PayoutInfo/index.vue
@@ -1,0 +1,141 @@
+<template>
+  <q-page padding class="q-pa-md">
+    <div class="row q-col-gutter-md justify-center">
+      <div class="col-12 col-md-8">
+        
+        <q-banner 
+          rounded 
+          class="q-mb-md q-pa-md"
+          :class="$q.dark.isActive ? 'bg-grey-9 text-grey-3' : 'bg-blue-1 text-blue-9'"
+        >
+          <template v-slot:avatar>
+            <q-icon name="info" :color="$q.dark.isActive ? 'accent' : 'primary'" size="sm" />
+          </template>
+          <div class="text-weight-medium">
+            ¡Registra la cuenta donde recibirás tus ganancias! Al completar tus eventos, utilizaremos esta información para transferirte tus fondos de manera segura a través de OpenPay. Asegúrate de verificar que todos tus datos sean correctos.
+          </div>
+        </q-banner>
+
+        <q-card 
+          class="q-pa-sm" 
+          flat 
+          bordered
+          :class="$q.dark.isActive ? 'bg-grey-10 text-white border-grey-9' : 'bg-white text-black'"
+        >
+          <q-card-section>
+            <div class="text-h6 text-weight-bold text-accent">
+              <q-icon name="account_balance" class="q-mr-sm" />
+              Datos de Cobro
+            </div>
+            <div class="text-subtitle2" :class="$q.dark.isActive ? 'text-grey-5' : 'text-grey-7'">
+              Configura tu cuenta bancaria destino para transferencias electrónicas.
+            </div>
+          </q-card-section>
+
+          <q-separator :dark="$q.dark.isActive" inset />
+
+          <q-card-section>
+            <q-form @submit="savePayoutInfo" class="q-gutter-md">
+                <q-input
+                    outlined
+                    :bg-color="$q.dark.isActive ? '' : 'grey-2'"
+                    :dark="$q.dark.isActive"
+                    v-model="payoutData.account_holder"
+                    label="Titular de la cuenta *"
+                    hint="Nombre completo del dueño de la cuenta o razón social"
+                    lazy-rules
+                    :rules="[ val => val && val.length > 0 || 'El nombre del titular es obligatorio' ]"
+                />
+                <q-select
+                    outlined
+                    :bg-color="$q.dark.isActive ? '' : 'grey-2'"
+                    :dark="$q.dark.isActive"
+                    v-model="payoutData.bank_name"
+                    :options="bankOptions"
+                    label="Banco *"
+                    lazy-rules
+                    :rules="[ val => val && val.length > 0 || 'Debes seleccionar un banco' ]"
+                />
+                <q-input
+                    outlined
+                    :bg-color="$q.dark.isActive ? '' : 'grey-2'"
+                    :dark="$q.dark.isActive"
+                    v-model="payoutData.clabe"
+                    label="CLABE Interbancaria *"
+                    mask="##################"
+                    unmasked-value
+                    hint="Clave de 18 dígitos numéricos para transferencias SPEI"
+                    lazy-rules
+                    :rules="[
+                    val => val && val.length === 18 || 'La CLABE debe tener exactamente 18 dígitos',
+                    val => /^\d+$/.test(val) || 'La CLABE solo debe contener números'
+                    ]"
+                />
+                <q-input
+                    outlined
+                    :bg-color="$q.dark.isActive ? '' : 'grey-2'"
+                    :dark="$q.dark.isActive"
+                    v-model="payoutData.rfc"
+                    label="RFC (Opcional)"
+                    mask="XXXX######XXX"
+                    hint="RFC asociado a la cuenta (12 o 13 caracteres)"
+                    style="text-transform: uppercase;"
+                />
+                <div class="row justify-end q-mt-lg">
+                    <q-btn 
+                    label="Guardar Información" 
+                    type="submit" 
+                    color="accent" 
+                    class="text-weight-bold"
+                    />
+                </div>
+            </q-form>
+          </q-card-section>
+        </q-card>
+
+      </div>
+    </div>
+  </q-page>
+</template>
+
+<script>
+import { ref } from "vue";
+import { useQuasar } from "quasar";
+
+export default {
+  name: "PayoutInfoPage",
+  setup() {
+    const $q = useQuasar();
+
+    const payoutData = ref({
+      account_holder: "",
+      bank_name: "",
+      clabe: "",
+      rfc: ""
+    });
+
+    const bankOptions = [
+      "BBVA", "Banamex", "Santander", "Banorte", "HSBC", 
+      "Scotiabank", "Banco Azteca", "BanCoppel", "Inbursa", "STP"
+    ];
+
+    function savePayoutInfo() {
+      $q.notify({
+        color: "primary",
+        textColor: "white",
+        icon: "cloud_done",
+        message: "¡Datos de cobro registrados localmente con éxito!",
+        position: "bottom"
+      });
+      
+      console.log("Datos listos para enviar al backend en el futuro:", payoutData.value);
+    }
+
+    return {
+      payoutData,
+      bankOptions,
+      savePayoutInfo
+    };
+  }
+};
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -221,6 +221,17 @@ const routes = [
           permissions: ["view-profile-artist"],
         },
       },
+      {
+        name: "artist.payout-info",
+        path: "/artist/payout-info",
+        component: () => import("pages/Artist/PayoutInfo/index.vue"),
+        meta: {
+          title: "Datos de Cobro",
+          middleware: [Middlewares.checkPermissions],
+          requireLogin: true,
+          permissions: ["view-profile-artist"], 
+        },
+      },
       // Fin de rutas del artista
 
       // Rutas del cliente


### PR DESCRIPTION
## Description
This PR introduces the frontend module for artists to register their bank payout details. This module allows artists to securely save their account details (Holder Name, Bank, and 18-digit CLABE number) so that the platform can disburse event funds securely via OpenPay once bookings are completed. 

The implementation focuses purely on user experience, responsiveness, and dark/light mode adaptability before connecting it to the backend infrastructure in future tasks.

## Changes Made
- **New Page Component:** Created `src/pages/Artist/PayoutInfo/index.vue` housing the responsive Quasar payout form.
- **Dynamic Theme Adaptability:** Configured the layout card, background separators, and inputs to dynamically shift styles based on `$q.dark.isActive`. Inputs utilize an `outlined` style with a custom `grey-2` background in light mode to preserve strict visual contrast.
- **Form Masking & Validation:** Embedded strict validation rules requiring an exact 18-digit numerical string for the Mexican CLABE input field using Quasar masks.
- **Informative UX Banner:** Embedded an elegant contextual alert banner at the top explaining the purpose of gathering this financial routing data (OpenPay payout distribution mechanics).
- **Navigation Routing:** Added the new child route under the dashboard structure inside `src/router/routes.js` bound to the existing `"view-profile-artist"` guard permissions. Incorporated navigation list items inside both `MainLayout.vue` and `Dashboard.vue`.

## How to Test
1. Switch to your local feature branch and run your Quasar dev server.
2. Log in as an account containing the `artista` role.
3. Access the sidebar navigation or dashboard links and click **Datos de Cobro**.
4. Test the theme switch toggle; ensure fields shift from deep grises to an outlined structure with soft `grey-2` filling when moving to light mode.
5. Attempt to insert letters or short combinations into the CLABE input field to verify mask boundaries and 18-character restriction warnings.