### PR TITLE
Add navigation links to genre buttons in artist profile

### DIFF
--- a/src/pages/Client/MusicalGenders/show.vue
+++ b/src/pages/Client/MusicalGenders/show.vue
@@ -33,6 +33,7 @@
                 size="xs"
                 class="q-mr-sm q-mt-md outline"
                 :label="musicalGender.name"
+                @click="$router.push({ name: 'client.view-groups-by-genders-search', params: { slug: musicalGender.slug } })"
               />
             </div>
           </div>


### PR DESCRIPTION
**Summary**

This PR adds the corresponding navigation links to the genre buttons displayed in the artist information page.

Users can now navigate directly to the related genre section by interacting with the genre buttons, improving discoverability and making it easier to browse artists by musical genre.

**📁 Files Modified**

Frontend

Artist Profile

- src/pages/Client/MusicalGenders/show.vue