### PR TITLE
Increase image upload limit to 20MB and improve gallery UX

### DIFF
--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -64,7 +64,8 @@
     </h3>
     <div>
       <q-carousel
-      class="q-mt-xl"
+        class="q-mt-xl"
+        :style="fullscreen ? 'height: 100vh' : 'height: 400px'"
         swipeable
         animated
         thumbnails
@@ -75,6 +76,7 @@
         arrows
         transition-prev="slide-right"
         transition-next="slide-left"
+        @keyup.esc="fullscreen = false"
       >
         <q-carousel-slide
           v-for="(gallery, index) in galleryArtist"
@@ -84,13 +86,14 @@
         />
 
         <template v-slot:control>
-          <q-carousel-control position="bottom-right" :offset="[18, 18]">
+          <q-carousel-control position="top-right" :offset="[18, 18]">
             <q-btn
               push
               round
               dense
               color="white"
               text-color="primary"
+              size="lg"
               :icon="fullscreen ? 'fullscreen_exit' : 'fullscreen'"
               @click="fullscreen = !fullscreen"
             />
@@ -102,27 +105,24 @@
     <section>
       <div class="q-pa-md q-gutter-sm">
         <q-dialog v-model="formGalleryEdit" persistent>
-          <q-card style="max-width: 360px">
-            <q-card-section>
+          <q-card style="min-width: 360px; max-width: 95vw">
+            <q-card-section class="row items-center q-pb-sm">
               <div class="text-h6">Editar galería de imágenes</div>
-              <p class="">
-                Todas las imágenes anteriores serán eliminadas y sustituidas por
-                las que selecciones.
-                ¿Estás seguro de eliminar las imágenes anteriores?
-              </p>
-              <q-btn
-                :disable="btnDelete"
-                label="Confirmar"
-                color="red"
-                @click="formDelete"
-              />
+              <q-space />
+              <q-btn icon="close" flat round dense v-close-popup />
             </q-card-section>
 
-            <q-card-section class="q-pt-none">
+            <q-separator />
+
+            <q-card-section>
+              <div class="text-caption text-grey q-mb-md">
+                Puedes agregar imágenes nuevas o eliminar todas y empezar de nuevo.
+                Máximo 5 imágenes en total.
+              </div>
+
               <q-uploader
                 ref="uploaderEdit"
-                :disable="formGalleryShow"
-                label="Selecciona las imagenes (Max 5)"
+                label="Agregar imágenes (Max 5)"
                 max-files="5"
                 multiple
                 accept=".jpg, .jpeg, .png, .jpe"
@@ -130,20 +130,26 @@
                 @added="(files) => validateAddedFiles(files, 'uploaderEdit')"
                 @rejected="onRejected"
                 color="accent"
-                max-file-size="1000000"
-                max-total-size="5000000"
+                max-file-size="20971520"
+                max-total-size="104857600"
+                class="q-mb-md full-width"
               />
-              <q-card-actions align="right" class="text-primary q-mt-md">
-                <q-btn
-                  label="Cancelar"
-                  type="reset"
-                  color="primary"
-                  flat
-                  v-close-popup
-                  class="q-ml-sm"
-                />
-              </q-card-actions>
+
+              <q-btn
+                outline
+                rounded
+                color="negative"
+                icon="delete_sweep"
+                label="Eliminar todas las imágenes"
+                class="full-width"
+                @click="formDelete"
+              />
             </q-card-section>
+
+            <q-separator />
+            <q-card-actions align="right" class="q-pa-sm">
+              <q-btn flat label="Cerrar" color="primary" v-close-popup />
+            </q-card-actions>
           </q-card>
         </q-dialog>
       </div>
@@ -349,12 +355,13 @@ export default {
           cancel: true,
           persistent: true,
         })
-        .onOk(() => {
+        .onOk(async() => {
           try {
             this.btnDelete = true;
             this.formGalleryShow = false;
             let option = "Yes";
             this.deleteGalleryArtist(option);
+            await this.gettGalleryArtist();
             this.$q.notify({
               type: "positive",
               message: `Eliminado correctamente`,

--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -296,6 +296,8 @@ export default {
         type: "negative",
         message: "Revisa que el formato de la imagen sea el esperado (jpg, png, jpeg, jpe) y que el tamaño no supere lo permitido.",
       });
+      this.formGalleryEdit = false;
+      await this.gettGalleryArtist();
     }
   },
 
@@ -351,28 +353,25 @@ export default {
       this.$q
         .dialog({
           title: "Mensaje de confirmación",
-          message: `¿Estás seguro de que quieres actualizar tu galería de imágenes?`,
+          message: `¿Estás seguro de que quieres eliminar todas las imágenes?`,
           cancel: true,
           persistent: true,
         })
-        .onOk(async() => {
+        .onOk(async () => {
           try {
-            this.btnDelete = true;
-            this.formGalleryShow = false;
             let option = "Yes";
-            this.deleteGalleryArtist(option);
-            await this.gettGalleryArtist();
+            await this.deleteGalleryArtist(option);
+            this.showGallery = false;
+            this.formGalleryEdit = false;
             this.$q.notify({
               type: "positive",
               message: `Eliminado correctamente`,
             });
           } catch (err) {
-            if (err.response.data.message) {
-              $q.notify({
-                type: "negative",
-                message: err.response.data.message,
-              });
-            }
+            this.$q.notify({
+              type: "negative",
+              message: err?.response?.data?.message || "Error al eliminar",
+            });
           }
         });
     },

--- a/src/components/Artist/NoticeGallery.vue
+++ b/src/components/Artist/NoticeGallery.vue
@@ -105,21 +105,18 @@
     <section>
       <div class="q-pa-md q-gutter-sm">
         <q-dialog v-model="formGalleryEdit" persistent>
-          <q-card style="min-width: 360px; max-width: 95vw">
+          <q-card style="min-width: 360px; max-width: 760px">
             <q-card-section class="row items-center q-pb-sm">
               <div class="text-h6">Editar galería de imágenes</div>
               <q-space />
               <q-btn icon="close" flat round dense v-close-popup />
             </q-card-section>
-
             <q-separator />
-
             <q-card-section>
               <div class="text-caption text-grey q-mb-md">
                 Puedes agregar imágenes nuevas o eliminar todas y empezar de nuevo.
                 Máximo 5 imágenes en total.
               </div>
-
               <q-uploader
                 ref="uploaderEdit"
                 label="Agregar imágenes (Max 5)"
@@ -134,7 +131,6 @@
                 max-total-size="104857600"
                 class="q-mb-md full-width"
               />
-
               <q-btn
                 outline
                 rounded
@@ -145,7 +141,6 @@
                 @click="formDelete"
               />
             </q-card-section>
-
             <q-separator />
             <q-card-actions align="right" class="q-pa-sm">
               <q-btn flat label="Cerrar" color="primary" v-close-popup />

--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -147,7 +147,7 @@
                   filled
                   class="q-mt-sm"
                   style="max-width: 200px"
-                  max-file-size="1000000"
+                  max-file-size="20971520"
                   counter
                   @rejected="onRejected"
                   lazy-rules
@@ -155,7 +155,7 @@
                   <template v-slot:prepend>
                     <q-icon name="attach_file" />
                   </template>
-                  <template v-slot:hint>Máximo 1MG</template>
+                  <template v-slot:hint>Máximo 20 MB</template>
                 </q-file>
               </div>
 
@@ -262,7 +262,7 @@
                   filled
                   class="q-mt-sm"
                   style="max-width: 200px"
-                  max-file-size="1000000"
+                  max-file-size="20971520"
                   counter
                   @rejected="onRejected"
                   lazy-rules
@@ -270,7 +270,7 @@
                   <template v-slot:prepend>
                     <q-icon name="attach_file" />
                   </template>
-                  <template v-slot:hint>Máximo 1MG</template>
+                  <template v-slot:hint>Máximo 20MB</template>
                 </q-file>
               </div>
 
@@ -591,7 +591,7 @@
                   filled
                   class="q-mt-sm"
                   style="max-width: 200px"
-                  max-file-size="1000000"
+                  max-file-size="20971520"
                   counter
                   @rejected="onRejectedArtists"
                   lazy-rules
@@ -599,7 +599,7 @@
                   <template v-slot:prepend>
                     <q-icon name="attach_file" />
                   </template>
-                  <template v-slot:hint>Máximo 1MG</template>
+                  <template v-slot:hint>Máximo 20 MB</template>
                 </q-file>
               </div>
               <div class="col-11">
@@ -704,7 +704,7 @@
                   filled
                   class="q-mt-sm"
                   style="max-width: 200px"
-                  max-file-size="1000000"
+                  max-file-size="20971520"
                   counter
                   @rejected="onRejected"
                   lazy-rules
@@ -712,7 +712,7 @@
                   <template v-slot:prepend>
                     <q-icon name="attach_file" />
                   </template>
-                  <template v-slot:hint>Máximo 1MG</template>
+                  <template v-slot:hint>Máximo 20 MB</template>
                 </q-file>
               </div>
               <p></p>
@@ -912,12 +912,12 @@ export default {
             message: `Ingresa una foto del manager`,
           });
         } else {
-          if (this.formCreate.image_artist.size > 1000000) {
+          if (this.formCreate.image_artist.size > 20971520) {
             this.$q.notify({
               type: "negative",
               message: `El tamaño de la imagen del grupo excede de lo permitido`,
             });
-          } else if (this.formCreate.image_manager.size > 1000000) {
+          } else if (this.formCreate.image_manager.size > 20971520) {
             this.$q.notify({
               type: "negative",
               message: `El tamaño de la imagen del manager excede de lo permitido`,
@@ -1065,12 +1065,12 @@ export default {
 
     async editArtist() {
       try {
-        if (this.formCreate.image_artist.size > 1000000) {
+        if (this.formCreate.image_artist.size > 20971520) {
           this.$q.notify({
             type: "negative",
             message: `El tamaño de la imagen del grupo excede de lo permitido`,
           });
-        } else if (this.formCreate.image_manager.size > 1000000) {
+        } else if (this.formCreate.image_manager.size > 20971520) {
           this.$q.notify({
             type: "negative",
             message: `El tamaño de la imagen del manager excede de lo permitido`,

--- a/src/pages/Artist/NewArtist/index.vue
+++ b/src/pages/Artist/NewArtist/index.vue
@@ -901,104 +901,103 @@ export default {
     async createNewArtist() {
       try {
         this.btnE = false;
-        if (this.formCreate.image_artist.length == 0) {
-          this.$q.notify({
-            type: "negative",
-            message: `Ingresa una foto de grupo o artista`,
-          });
-        } else if (this.formCreate.image_manager.length == 0) {
-          this.$q.notify({
-            type: "negative",
-            message: `Ingresa una foto del manager`,
-          });
-        } else {
-          if (this.formCreate.image_artist.size > 20971520) {
+
+        switch (true) {
+          case this.formCreate.image_artist.length == 0:
+            this.$q.notify({
+              type: "negative",
+              message: `Ingresa una foto de grupo o artista`,
+            });
+            return;
+          case this.formCreate.image_manager.length == 0:
+            this.$q.notify({
+              type: "negative",
+              message: `Ingresa una foto del manager`,
+            });
+            return;
+          case this.formCreate.image_artist.size > 20971520:
             this.$q.notify({
               type: "negative",
               message: `El tamaño de la imagen del grupo excede de lo permitido`,
             });
-          } else if (this.formCreate.image_manager.size > 20971520) {
+            return;
+          case this.formCreate.image_manager.size > 20971520:
             this.$q.notify({
               type: "negative",
               message: `El tamaño de la imagen del manager excede de lo permitido`,
             });
-          } else {
-            let InstFormData = new FormData();
-            InstFormData.append("name", this.formCreate.name);
-            InstFormData.append("members", this.formCreate.members);
-            InstFormData.append("history", this.formCreate.history);
-            InstFormData.append("zone", this.formCreate.zone);
-            InstFormData.append("price_hour", this.formCreate.price_hour);
-            InstFormData.append("image_artist", this.formCreate.image_artist);
-            InstFormData.append(
-              "extra_kilometre",
-              this.formCreate.extra_kilometre
-            );
-            InstFormData.append("coverage_radius", this.formCreate.coverage_radius);
-            InstFormData.append("name_manager", this.formCreate.name_manager);
-            InstFormData.append("phone_manager", this.formCreate.phone_manager);
-            InstFormData.append("email_manager", this.formCreate.email_manager);
-            InstFormData.append("image_manager", this.formCreate.image_manager);
-            const selection = JSON.stringify(this.formCreate.selection);
-            InstFormData.append("selection", selection);
+            return;
+        }
 
-            const socialDomainMap = {
-              Instagram: 'instagram.com',
-              'X (Twitter)': 'twitter.com',
-              YouTube: 'youtube.com',
-              Facebook: 'facebook.com',
-              TikTok: 'tiktok.com',
-              Spotify: 'spotify.com',
-              'Apple Music': 'music.apple.com',
-              SoundCloud: 'soundcloud.com',
-              Bandcamp: 'bandcamp.com',
-              LinkedIn: 'linkedin.com',
-            };
+        let InstFormData = new FormData();
+        InstFormData.append("name", this.formCreate.name);
+        InstFormData.append("members", this.formCreate.members);
+        InstFormData.append("history", this.formCreate.history);
+        InstFormData.append("zone", this.formCreate.zone);
+        InstFormData.append("price_hour", this.formCreate.price_hour);
+        InstFormData.append("image_artist", this.formCreate.image_artist);
+        InstFormData.append("extra_kilometre", this.formCreate.extra_kilometre);
+        InstFormData.append("coverage_radius", this.formCreate.coverage_radius);
+        InstFormData.append("name_manager", this.formCreate.name_manager);
+        InstFormData.append("phone_manager", this.formCreate.phone_manager);
+        InstFormData.append("email_manager", this.formCreate.email_manager);
+        InstFormData.append("image_manager", this.formCreate.image_manager);
+        const selection = JSON.stringify(this.formCreate.selection);
+        InstFormData.append("selection", selection);
 
-            for (const red of this.formCreate.social_media) {
-              if (!red.name || !red.url) {
-                this.$q.notify({
-                  type: 'negative',
-                  message: 'Cada red social debe tener nombre y URL.',
-                });
-                return;
-              }
+        const socialDomainMap = {
+          Instagram: 'instagram.com',
+          'X (Twitter)': 'twitter.com',
+          YouTube: 'youtube.com',
+          Facebook: 'facebook.com',
+          TikTok: 'tiktok.com',
+          Spotify: 'spotify.com',
+          'Apple Music': 'music.apple.com',
+          SoundCloud: 'soundcloud.com',
+          Bandcamp: 'bandcamp.com',
+          LinkedIn: 'linkedin.com',
+        };
 
-              try {
-                new URL(red.url);
-              } catch {
-                this.$q.notify({
-                  type: 'negative',
-                  message: `La URL de ${red.name} no es válida.`,
-                });
-                return;
-              }
-
-              const expectedDomain = socialDomainMap[red.name];
-              const actualHost = new URL(red.url).hostname.replace('www.', '');
-
-              if (expectedDomain && !actualHost.includes(expectedDomain)) {
-                this.$q.notify({
-                  type: 'negative',
-                  message: `La URL de ${red.name} debe pertenecer a ${expectedDomain}.`,
-                });
-                return;
-              }
-            }
-
-            const social_media = JSON.stringify(this.formCreate.social_media);
-            InstFormData.append("social_media", social_media);
-
-            // console.log(InstFormData);
-            await this.createArtist(InstFormData);
-            this.gettArtist();
+        for (const red of this.formCreate.social_media) {
+          if (!red.name || !red.url) {
             this.$q.notify({
-              type: "positive",
-              message: `Infromación guardada correctamente`,
+              type: 'negative',
+              message: 'Cada red social debe tener nombre y URL.',
             });
-            //this.onReset();
+            return;
+          }
+
+          try {
+            new URL(red.url);
+          } catch {
+            this.$q.notify({
+              type: 'negative',
+              message: `La URL de ${red.name} no es válida.`,
+            });
+            return;
+          }
+
+          const expectedDomain = socialDomainMap[red.name];
+          const actualHost = new URL(red.url).hostname.replace('www.', '');
+
+          if (expectedDomain && !actualHost.includes(expectedDomain)) {
+            this.$q.notify({
+              type: 'negative',
+              message: `La URL de ${red.name} debe pertenecer a ${expectedDomain}.`,
+            });
+            return;
           }
         }
+
+        const social_media = JSON.stringify(this.formCreate.social_media);
+        InstFormData.append("social_media", social_media);
+
+        await this.createArtist(InstFormData);
+        this.gettArtist();
+        this.$q.notify({
+          type: "positive",
+          message: `Infromación guardada correctamente`,
+        });
       } catch (err) {
         if (err.response.data.message) {
           $q.notify({
@@ -1065,106 +1064,104 @@ export default {
 
     async editArtist() {
       try {
-        if (this.formCreate.image_artist.size > 20971520) {
-          this.$q.notify({
-            type: "negative",
-            message: `El tamaño de la imagen del grupo excede de lo permitido`,
-          });
-        } else if (this.formCreate.image_manager.size > 20971520) {
-          this.$q.notify({
-            type: "negative",
-            message: `El tamaño de la imagen del manager excede de lo permitido`,
-          });
-        } else {
-          let InstFormData = new FormData();
-          InstFormData.append("id", this.formCreate.id);
-          InstFormData.append("name", this.formCreate.name);
-          InstFormData.append("members", this.formCreate.members);
-          InstFormData.append("history", this.formCreate.history);
-          InstFormData.append("zone", this.formCreate.zone);
-          InstFormData.append("price_hour", this.formCreate.price_hour);
-          if (this.formCreate.image_artist.size > 1) {
-            console.log("Entro 1");
-            InstFormData.append("image_artist", this.formCreate.image_artist);
-          }
-          if (this.formCreate.image_manager.size > 1) {
-            console.log("Entro 2");
-            InstFormData.append("image_manager", this.formCreate.image_manager);
-          }
-          InstFormData.append(
-            "extra_kilometre",
-            this.formCreate.extra_kilometre
-          );
-          InstFormData.append("coverage_radius", this.formCreate.coverage_radius);
-          InstFormData.append("name_manager", this.formCreate.name_manager);
-          InstFormData.append("phone_manager", this.formCreate.phone_manager);
-          InstFormData.append("email_manager", this.formCreate.email_manager);
-          const selection = JSON.stringify(this.formCreate.selection);
-          InstFormData.append("selection", selection);
-
-          const socialDomainMap = {
-            Instagram: 'instagram.com',
-            'X (Twitter)': 'twitter.com',
-            YouTube: 'youtube.com',
-            Facebook: 'facebook.com',
-            TikTok: 'tiktok.com',
-            Spotify: 'spotify.com',
-            'Apple Music': 'music.apple.com',
-            SoundCloud: 'soundcloud.com',
-            Bandcamp: 'bandcamp.com',
-            LinkedIn: 'linkedin.com',
-          };
-
-          for (const red of this.formCreate.social_media) {
-            if (!red.name || !red.url) {
-              this.$q.notify({
-                type: 'negative',
-                message: 'Cada red social debe tener nombre y URL.',
-              });
-              return;
-            }
-
-            try {
-              new URL(red.url);
-            } catch {
-              this.$q.notify({
-                type: 'negative',
-                message: `La URL de ${red.name} no es válida.`,
-              });
-              return;
-            }
-
-            const expectedDomain = socialDomainMap[red.name];
-            const actualHost = new URL(red.url).hostname.replace('www.', '');
-
-            if (expectedDomain && !actualHost.includes(expectedDomain)) {
-              this.$q.notify({
-                type: 'negative',
-                message: `La URL de ${red.name} debe pertenecer a ${expectedDomain}.`,
-              });
-              return;
-            }
-          }
-
-          const social_media = JSON.stringify(this.formCreate.social_media);
-          InstFormData.append("social_media", social_media);
-
-          // console.log(InstFormData);
-
-          let formUpdate = {
-            id: this.formCreate.id,
-            form: InstFormData,
-          };
-          await this.updateArtist(formUpdate);
-          this.gettArtist();
-          this.showEdit = "false";
-          this.showInfo = "false";
-          this.$q.notify({
-            type: "positive",
-            message: `Infromación guardada correctamente`,
-          });
-          this.onReset();
+        switch (true) {
+          case this.formCreate.image_artist.size > 20971520:
+            this.$q.notify({
+              type: "negative",
+              message: `El tamaño de la imagen del grupo excede de lo permitido`,
+            });
+            return;
+          case this.formCreate.image_manager.size > 20971520:
+            this.$q.notify({
+              type: "negative",
+              message: `El tamaño de la imagen del manager excede de lo permitido`,
+            });
+            return;
         }
+
+        let InstFormData = new FormData();
+        InstFormData.append("id", this.formCreate.id);
+        InstFormData.append("name", this.formCreate.name);
+        InstFormData.append("members", this.formCreate.members);
+        InstFormData.append("history", this.formCreate.history);
+        InstFormData.append("zone", this.formCreate.zone);
+        InstFormData.append("price_hour", this.formCreate.price_hour);
+        if (this.formCreate.image_artist.size > 1) {
+          console.log("Entro 1");
+          InstFormData.append("image_artist", this.formCreate.image_artist);
+        }
+        if (this.formCreate.image_manager.size > 1) {
+          console.log("Entro 2");
+          InstFormData.append("image_manager", this.formCreate.image_manager);
+        }
+        InstFormData.append("extra_kilometre", this.formCreate.extra_kilometre);
+        InstFormData.append("coverage_radius", this.formCreate.coverage_radius);
+        InstFormData.append("name_manager", this.formCreate.name_manager);
+        InstFormData.append("phone_manager", this.formCreate.phone_manager);
+        InstFormData.append("email_manager", this.formCreate.email_manager);
+        const selection = JSON.stringify(this.formCreate.selection);
+        InstFormData.append("selection", selection);
+
+        const socialDomainMap = {
+          Instagram: 'instagram.com',
+          'X (Twitter)': 'twitter.com',
+          YouTube: 'youtube.com',
+          Facebook: 'facebook.com',
+          TikTok: 'tiktok.com',
+          Spotify: 'spotify.com',
+          'Apple Music': 'music.apple.com',
+          SoundCloud: 'soundcloud.com',
+          Bandcamp: 'bandcamp.com',
+          LinkedIn: 'linkedin.com',
+        };
+
+        for (const red of this.formCreate.social_media) {
+          if (!red.name || !red.url) {
+            this.$q.notify({
+              type: 'negative',
+              message: 'Cada red social debe tener nombre y URL.',
+            });
+            return;
+          }
+
+          try {
+            new URL(red.url);
+          } catch {
+            this.$q.notify({
+              type: 'negative',
+              message: `La URL de ${red.name} no es válida.`,
+            });
+            return;
+          }
+
+          const expectedDomain = socialDomainMap[red.name];
+          const actualHost = new URL(red.url).hostname.replace('www.', '');
+
+          if (expectedDomain && !actualHost.includes(expectedDomain)) {
+            this.$q.notify({
+              type: 'negative',
+              message: `La URL de ${red.name} debe pertenecer a ${expectedDomain}.`,
+            });
+            return;
+          }
+        }
+
+        const social_media = JSON.stringify(this.formCreate.social_media);
+        InstFormData.append("social_media", social_media);
+
+        let formUpdate = {
+          id: this.formCreate.id,
+          form: InstFormData,
+        };
+        await this.updateArtist(formUpdate);
+        this.gettArtist();
+        this.showEdit = "false";
+        this.showInfo = "false";
+        this.$q.notify({
+          type: "positive",
+          message: `Infromación guardada correctamente`,
+        });
+        this.onReset();
       } catch (err) {
         if (err.response.data.message) {
           $q.notify({

--- a/src/store/artist/galleryArtist/actions.js
+++ b/src/store/artist/galleryArtist/actions.js
@@ -20,8 +20,8 @@ export const upDateGalleryArtist = async ({ dispatch }, payload) => {
   });
 };
 
-export const deleteGalleryArtist= async ( payload) => {
-  await api.delete('/api/artist-new/gallery-artist-delete',payload).then((response) => {
-   
+export const deleteGalleryArtist = async ({ dispatch }, payload) => {
+  await api.delete('/api/artist-new/gallery-artist-delete').then(() => {
+    dispatch("getGalleryArtist");
   });
 };


### PR DESCRIPTION
## Description
Increased the maximum file size limit for artist and manager image uploads from 1MB to 20MB to allow high-resolution files. Also improved the photo carousel controls and the gallery editing user experience in the artist dashboard.

## Why
Artists were frequently reporting upload failures because modern smartphone photos and high-quality portfolio images easily exceed the previous 1MB restriction. Additionally, the gallery modal lacked a clear way to wipe out existing images, leading to a clunky replacement workflow.

## Impact
- **User Experience:** Artists can now upload high-res assets without compressing them manually beforehand.
- **UI Stability:** The carousel is now fully responsive in full-screen mode, and users can intuitively exit using the `ESC` key.

## Changes
- **src/components/Artist/NoticeGallery.vue**:
  - Updated `max-file-size` to `20971520` (20MB) and `max-total-size` to `104857600` (100MB).
  - Added responsive height toggle (`100vh` vs `400px`) for full-screen mode and `ESC` key handler.
  - Repositioned carousel control button to top-right with `lg` size.
  - Added an explicit "Eliminar todas las imágenes" button (`delete_sweep`) with proper async state handling.
- **src/pages/Artist/NewArtist/index.vue**:
  - Updated file size validation constraints and UI hints to reflect the 20MB limit.

## Testing Plan
1. **Upload Testing:** Go to the "New Artist" form and verify that an image larger than 1MB (but under 20MB) uploads successfully. Try uploading a file > 20MB and verify the rejection notice triggers.
2. **Carousel UX:** Open the artist gallery, trigger full-screen mode, check that it stretches to `100vh`, and press `ESC` to ensure it exits correctly.
3. **Gallery Reset:** Open the gallery edit modal, click "Eliminar todas las imágenes", confirm the dialog, and verify the uploader resets and fetches the updated empty state.