### PR TITLE
Add purchase date column and delegate cart completion to step validator

### DIFF
--- a/src/pages/Artist/Sales.vue
+++ b/src/pages/Artist/Sales.vue
@@ -65,18 +65,28 @@
         </q-td>
       </template>
 
+      <template v-slot:body-cell-fecha_compra="props">
+        <q-td :props="props">
+          <q-icon name="shopping_cart" size="14px" color="grey" class="q-mr-xs" />
+          <span class="text-weight-medium">{{ formatDate(props.row.created_at) }}</span>
+        </q-td>
+      </template>
+
+      <template v-slot:body-cell-status="props">
+        <q-td :props="props" class="text-center">
+          <q-badge
+            :color="props.row.status === 'completed' ? 'positive' : 'warning'"
+            :label="props.row.status === 'completed' ? 'Completada' : 'Pendiente'"
+            class="q-pa-sm"
+          />
+        </q-td>
+      </template>
+
       <template v-slot:body-cell-amount="props">
         <q-td :props="props">
           <span class="text-weight-bold text-positive text-h6">
             ${{ Number(props.row.amount).toLocaleString('es-MX') }}
           </span>
-        </q-td>
-      </template>
-
-      <template v-slot:body-cell-fecha_compra="props">
-        <q-td :props="props">
-          <q-icon name="shopping_cart" size="14px" color="grey" class="q-mr-xs" />
-          <span class="text-weight-medium">{{ formatDate(props.row.created_at) }}</span>
         </q-td>
       </template>
 
@@ -130,19 +140,22 @@
                     </div>
                     <span v-if="!props.row.event_date" class="text-grey text-caption">Sin fecha</span>
                   </q-item-label>
+                  <q-item-label v-if="col.name === 'status'">
+                    <q-badge
+                      :color="props.row.status === 'completed' ? 'positive' : 'warning'"
+                      :label="props.row.status === 'completed' ? 'Completada' : 'Pendiente'"
+                      class="q-pa-sm"
+                    />
+                  </q-item-label>
                   <q-item-label v-if="col.name === 'amount'">
                     <span class="text-weight-bold text-positive text-h6">
                       ${{ Number(props.row.amount).toLocaleString('es-MX') }}
                     </span>
                   </q-item-label>
-                  <q-item-label v-if="col.name === 'fecha_compra'">
-                    <q-icon name="shopping_cart" size="14px" color="grey" class="q-mr-xs" />
-                    {{ formatDate(props.row.created_at) }}
-                  </q-item-label>
                   <q-item-label v-if="col.name === 'acciones'">
                     <q-btn flat rounded color="primary" label="Enviar Mensaje" @click="openChat(props.row)" />
                   </q-item-label>
-                  <q-item-label v-if="col.name !== 'cliente' && col.name !== 'lugar' && col.name !== 'evento' && col.name !== 'amount' && col.name !== 'acciones' && col.name !== 'fecha_compra'">
+                  <q-item-label v-if="col.name !== 'cliente' && col.name !== 'lugar' && col.name !== 'evento' && col.name !== 'acciones' && col.name !== 'fecha_compra' && col.name !== 'status' && col.name !== 'amount'">
                     {{ col.value }}
                   </q-item-label>
                 </q-item-section>
@@ -252,6 +265,13 @@ const columns = [
     sortable: true,
   },
   {
+    name: "fecha_compra",
+    label: "Fecha de compra",
+    align: "left",
+    field: "created_at",
+    sortable: true,
+  },
+  {
     name: "amount",
     label: "Monto",
     align: "left",
@@ -259,10 +279,10 @@ const columns = [
     sortable: true,
   },
   {
-    name: "fecha_compra",
-    label: "Fecha de compra",
-    align: "left",
-    field: "created_at",
+    name: "status",
+    label: "Estado",
+    align: "center",
+    field: "status",
     sortable: true,
   },
   {

--- a/src/pages/Artist/Sales.vue
+++ b/src/pages/Artist/Sales.vue
@@ -73,6 +73,13 @@
         </q-td>
       </template>
 
+      <template v-slot:body-cell-fecha_compra="props">
+        <q-td :props="props">
+          <q-icon name="shopping_cart" size="14px" color="grey" class="q-mr-xs" />
+          <span class="text-weight-medium">{{ formatDate(props.row.created_at) }}</span>
+        </q-td>
+      </template>
+
       <template v-slot:body-cell-acciones="props">
         <q-td :props="props" class="text-center">
           <q-btn flat rounded color="primary" label="Enviar Mensaje" @click="openChat(props.row)" />
@@ -128,10 +135,14 @@
                       ${{ Number(props.row.amount).toLocaleString('es-MX') }}
                     </span>
                   </q-item-label>
+                  <q-item-label v-if="col.name === 'fecha_compra'">
+                    <q-icon name="shopping_cart" size="14px" color="grey" class="q-mr-xs" />
+                    {{ formatDate(props.row.created_at) }}
+                  </q-item-label>
                   <q-item-label v-if="col.name === 'acciones'">
                     <q-btn flat rounded color="primary" label="Enviar Mensaje" @click="openChat(props.row)" />
                   </q-item-label>
-                  <q-item-label v-if="col.name !== 'cliente' && col.name !== 'lugar' && col.name !== 'evento' && col.name !== 'amount' && col.name !== 'acciones'">
+                  <q-item-label v-if="col.name !== 'cliente' && col.name !== 'lugar' && col.name !== 'evento' && col.name !== 'amount' && col.name !== 'acciones' && col.name !== 'fecha_compra'">
                     {{ col.value }}
                   </q-item-label>
                 </q-item-section>
@@ -245,6 +256,13 @@ const columns = [
     label: "Monto",
     align: "left",
     field: "amount",
+    sortable: true,
+  },
+  {
+    name: "fecha_compra",
+    label: "Fecha de compra",
+    align: "left",
+    field: "created_at",
     sortable: true,
   },
   {

--- a/src/pages/Client/ShoppingCart/dataClient.vue
+++ b/src/pages/Client/ShoppingCart/dataClient.vue
@@ -455,7 +455,7 @@
             </div>
 
             <q-stepper-navigation>
-              <q-btn rounded @click="paymentMethod === 'cash' ? payCash() : pay()" class="float-right q-mr-md q-mb-md" color="blue"
+              <q-btn rounded @click="validateStep2" class="float-right q-mr-md q-mb-md" color="blue"
                 label="Realizar Compra" />
               <q-btn flat @click="step = 2" color="primary" rounded label="Anterior" class="q-mr-sm float-right" />
             </q-stepper-navigation>


### PR DESCRIPTION
## Description
Introduced a "Fecha de compra" (Purchase Date) column with dedicated cell slots within the artist sales data table/grid views. Additionally, refactored the checkout flow button event to route through a dedicated step step-2 validation wrapper function.

## Why
Artists needed an explicit overview of when their bookings were paid for rather than just when the event itself takes place. In the checkout flow, calling the payment methods directly without passing validation logic bypassed structural form-field completeness assessments in step 2.

## Impact
- **UI Metrics:** Enhanced table clarity by integrating `created_at` records alongside visual cues.
- **Checkout Security:** Ensures user info data blocks validate structural fields securely via `validateStep2` prior to invoking payment endpoints.

## Changes
- **src/pages/Artist/Sales.vue**:
  - Registered `fecha_compra` column inside the metadata schema definition.
  - Formed a slot-based template override for `body-cell-fecha_compra` embedding a QIcon (`shopping_cart`) and text layouts.
  - Updated responsive list card iteration clauses to cleanly omit or inject the new element without breaking style rules.
- **src/pages/Client/ShoppingCart/dataClient.vue**:
  - Changed checkout completion action triggers from inline conditional hooks (`paymentMethod === 'cash' ? payCash() : pay()`) over to unified execution points via `validateStep2`.

## Testing Plan
1. **Sales Table:** Access the sales view as an artist and confirm that the purchase date appears formatted correctly inside both the desktop grid layout and responsive list.
2. **Cart Logic:** Complete step 2 in the checkout wizard, click "Realizar Compra", and ensure that validation executes before initiating the cash or card transaction.