### PR TITLE
Disable report action for non-completed sales and add mobile support

### DIFF
--- a/src/pages/Artist/Sales.vue
+++ b/src/pages/Artist/Sales.vue
@@ -105,6 +105,7 @@
             icon="report_problem"
             label="Reportar"
             size="sm"
+            :disable="props.row.status !== 'completed'"
             @click="goToReport(props.row)"
           />
         </q-td>
@@ -155,7 +156,19 @@
                   <q-item-label v-if="col.name === 'acciones'">
                     <q-btn flat rounded color="primary" label="Enviar Mensaje" @click="openChat(props.row)" />
                   </q-item-label>
-                  <q-item-label v-if="col.name !== 'cliente' && col.name !== 'lugar' && col.name !== 'evento' && col.name !== 'acciones' && col.name !== 'fecha_compra' && col.name !== 'status' && col.name !== 'amount'">
+                  <q-item-label v-if="col.name === 'report'">
+                    <q-btn
+                      flat
+                      rounded
+                      color="negative"
+                      icon="report_problem"
+                      label="Reportar"
+                      size="sm"
+                      :disable="props.row.status !== 'completed'"
+                      @click="goToReport(props.row)"
+                    />
+                  </q-item-label>
+                  <q-item-label v-if="col.name !== 'cliente' && col.name !== 'lugar' && col.name !== 'evento' && col.name !== 'acciones' && col.name !== 'report' && col.name !== 'fecha_compra' && col.name !== 'status' && col.name !== 'amount'">
                     {{ col.value }}
                   </q-item-label>
                 </q-item-section>


### PR DESCRIPTION
## 📝 Description
This PR updates the artist sales dashboard by adding validation logic to the "Reportar" action. The reporting button is now conditionally disabled based on the sale status. Additionally, the report action has been integrated into the responsive mobile list layout.

## 🎯 Why
Artists were previously able to click the report button on transactions that were still marked as `pending`. To protect system logic and optimize support workflows, reporting triggers must be strictly guarded and restricted only to `completed` transactions. The action was also missing from the responsive card slots, creating a feature gap on smaller viewports.

## ⚡ Impact
- **Business Logic:** Prevents premature or invalid dispute creation from the frontend.
- **UX Consistency:** Ensures identical action capability between desktop grids and responsive card views by implementing the `report` conditional block.

## 🛠️ Changes
- **src/pages/Artist/Sales.vue**:
  - Bound `:disable="props.row.status !== 'completed'"` to the desktop action button inside the table cell template.
  - Implemented a missing `v-if="col.name === 'report'"` block within the responsive mobile `<q-item-section>` wrapper.
  - Excluded the `report` column key inside the fallback metadata array filters to ensure custom cells don't print double values.

## 🧪 Testing Plan
1. **Desktop Flow:** Open the sales log grid view. Locate a sale where status is `Pending` and verify that the "Reportar" button is grayed out / unclickable. Locate a `Completed` sale and verify that the button is active.
2. **Mobile Layout Flow:** Shrink the viewport to trigger mobile presentation styles. Verify that the "Reportar" button appears correctly mapped inside the data cards and reflects the identical `:disable` states based on each row's payload properties.